### PR TITLE
Fix npm publish resolving tarball path as a GitHub repo spec

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -47,4 +47,11 @@ jobs:
           name: npm-package
           path: package
       - name: Publish the exact artifact produced by the unprivileged job
-        run: npm publish package/*.tgz --access public --provenance
+        run: |
+          shopt -s nullglob
+          tarballs=(package/*.tgz)
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "Expected exactly one tarball in package/, found ${#tarballs[@]}: ${tarballs[*]}" >&2
+            exit 1
+          fi
+          npm publish "./${tarballs[0]}" --access public --provenance


### PR DESCRIPTION
npm's package-spec parser treats 'package/foo.tgz' as GitHub shorthand <owner>/<repo> because it contains a slash and no leading './', so the publish step tried 'git ls-remote ssh://git@github.com/package/....git' and failed with exit code 128. Resolve the tarball explicitly, require exactly one, and pass it as './package/foo.tgz'.