### PR TITLE
Deserialize the instruction input without the stock entrypoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,13 @@ arrayref = "0.3.7"
 [profile.release]
 codegen-units = 1
 lto = "fat"
+# Kept on deliberately. Measured 2026-08 on SBPF v2: turning this off saves
+# 0-2.4% CU (about 118 CU on a single-order batch update, 400 on five orders,
+# nothing on deposit/withdraw/swap). In exchange every plain +, - and * that is
+# not explicitly checked (lamport fees, byte offsets, indices) would wrap
+# silently instead of failing the transaction, and the audits and formal
+# verification were done with it on. Prefer targeted wrapping ops with a
+# proof, like the entrypoint does, over flipping this.
 overflow-checks = true
 strip = "debuginfo"
 

--- a/programs/manifest/src/entrypoint.rs
+++ b/programs/manifest/src/entrypoint.rs
@@ -1,0 +1,313 @@
+//! Program entrypoint tuned for compute units.
+//!
+//! `solana_program::entrypoint!` decodes the runtime's serialized input buffer
+//! into a heap allocated `Vec<AccountInfo>`, reading every account field
+//! through a running byte offset and dropping the whole `Vec` (and every `Rc`
+//! in it) again when the instruction returns. This module produces the very
+//! same `solana_program::account_info::AccountInfo` values, so nothing else in
+//! the program changes, but:
+//!
+//! * accounts are written straight into a fixed-size stack array (no `Vec`,
+//!   no drop at the end),
+//! * each account header is read as one `#[repr(C)]` struct at a known
+//!   address instead of field-by-field offset arithmetic,
+//! * the only work that is left per account is the two `Rc<RefCell<_>>`
+//!   allocations that the `AccountInfo` type itself requires, and those go
+//!   through [`BumpAllocator`], a bump allocator whose allocation path is
+//!   about half the instructions of the `solana_program` default.
+//!
+//! Those two allocations are the floor for this account type, and they are
+//! most of what is left. Measured with the account sweep in
+//! `tests/cases/cu.rs`, this entrypoint costs 185 CU plus 72 per account; a
+//! variant that writes one raw pointer per account instead of the two
+//! `Rc<RefCell<_>>` costs 14 per account. So about 58 CU per account, four
+//! fifths of the per-account cost, is the `AccountInfo` type rather than the
+//! parsing.
+//!
+//! Reaching that floor needs a zero-copy account type such as pinocchio's
+//! `AccountInfo`, which is a single pointer into this same input buffer with
+//! the fields read through it on demand. That is not a drop-in replacement:
+//! it is a different type, so every processor, every wrapper in `validation/`,
+//! every CPI helper and the test fixtures would have to be written against it.
+//! The usual way around that is to port only the hottest instructions: keep a
+//! parallel zero-copy implementation of those handlers, their state and their
+//! CPIs, and dispatch on the instruction discriminant before deserializing, so
+//! everything else falls through to the ordinary path.
+//!
+//! That trade pays off when the hot instructions carry a dozen accounts each
+//! and what it deletes is a framework's per-account deserialization and
+//! validation, which costs far more than the 58 CU per account here. Neither
+//! holds for manifest: its instructions carry 3 to 6 accounts and the loaders
+//! in `validation/` are already thin. The saving would be about 290 CU on a
+//! five account wrapper batch update and 175 on the three account core batch
+//! update it calls, so under 500 CU on a transaction that costs about 27,000,
+//! in exchange for a second implementation of every ported instruction to keep
+//! correct and audited. If one instruction ever dominates the budget, porting
+//! only that one behind a discriminant check is the shape to reach for.
+//!
+//! Instructions with more than [`MAX_ACCOUNTS`] accounts fall back to the
+//! stock `solana_program` deserializer, so behavior is identical for every
+//! input.
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint::MAX_PERMITTED_DATA_INCREASE, pubkey::Pubkey,
+};
+use std::{
+    alloc::{GlobalAlloc, Layout},
+    cell::RefCell,
+    mem::{size_of, MaybeUninit},
+    ptr::{addr_of_mut, null_mut},
+    rc::Rc,
+    slice::{from_raw_parts, from_raw_parts_mut},
+};
+
+/// Most accounts that are deserialized onto the stack. Manifest instructions
+/// take at most 14 accounts, the wrapper 15 and the ui wrapper 20. Same bound
+/// as `solana_program::entrypoint_no_alloc!`. Larger instructions still work,
+/// they just take the heap allocating path.
+pub const MAX_ACCOUNTS: usize = 64;
+
+/// Program instruction processor signature, same as `solana_program`'s.
+pub type ProcessInstruction =
+    fn(&Pubkey, &[AccountInfo], &[u8]) -> solana_program::entrypoint::ProgramResult;
+
+/// Value of `RuntimeAccount::dup_info` when the account is not a duplicate.
+const NON_DUP_MARKER: u8 = u8::MAX;
+
+/// The runtime aligns the start of every account (and the trailing rent epoch)
+/// to this many bytes.
+const BPF_ALIGN_OF_U128: usize = 8;
+
+/// Fixed-size header the runtime serializes ahead of each non-duplicate
+/// account's data. Layout is defined by the SBF ABI (see
+/// `solana_program_entrypoint::deserialize`).
+#[repr(C)]
+struct RuntimeAccount {
+    /// [`NON_DUP_MARKER`], or the index of the earlier account this duplicates.
+    dup_info: u8,
+    is_signer: u8,
+    is_writable: u8,
+    executable: u8,
+    /// Runtime padding that the entrypoint fills with the account's original
+    /// data length. `AccountInfo::realloc` reads it back from the four bytes
+    /// immediately before `key`.
+    original_data_len: u32,
+    key: Pubkey,
+    owner: Pubkey,
+    lamports: u64,
+    data_len: u64,
+}
+
+const _: () = assert!(size_of::<RuntimeAccount>() == 88);
+
+/// Declares the program `entrypoint` symbol, the heap allocator and the
+/// default panic handler, like `solana_program::entrypoint!`, but using
+/// [`process_entrypoint`] for the deserialization and [`BumpAllocator`] as the
+/// heap. As with `solana_program`, a program that enables its own
+/// `custom-heap` feature keeps its own allocator.
+#[macro_export]
+macro_rules! entrypoint {
+    ($process_instruction:ident) => {
+        /// # Safety
+        ///
+        /// Only called by the Solana runtime with its serialized input buffer.
+        #[no_mangle]
+        pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
+            #[cfg(all(not(feature = "custom-heap"), target_os = "solana"))]
+            $crate::entrypoint::BumpAllocator::init();
+            $crate::entrypoint::process_entrypoint(input, $process_instruction)
+        }
+        #[cfg(all(not(feature = "custom-heap"), target_os = "solana"))]
+        #[global_allocator]
+        static A: $crate::entrypoint::BumpAllocator = $crate::entrypoint::BumpAllocator;
+        solana_program::custom_panic_default!();
+    };
+}
+
+/// Bump allocator over the program heap, like `solana_program`'s default
+/// allocator: memory is never freed, `realloc` is allocate-and-copy. The
+/// differences are that the cursor is initialized once by the entrypoint
+/// instead of being checked on every allocation, and that it grows upward so
+/// an allocation is an align, an add and a bounds check.
+///
+/// The cursor lives in the first word of the heap, so the usable heap is
+/// `HEAP_LENGTH - 8` bytes, the same as `solana_program`'s allocator.
+pub struct BumpAllocator;
+
+/// Address of the allocation cursor: the first word of the heap.
+const HEAP_CURSOR: *mut usize = solana_program::entrypoint::HEAP_START_ADDRESS as *mut usize;
+/// First usable heap byte, just after the cursor.
+const HEAP_BOTTOM: usize =
+    solana_program::entrypoint::HEAP_START_ADDRESS as usize + size_of::<usize>();
+/// One past the last usable heap byte.
+const HEAP_TOP: usize = solana_program::entrypoint::HEAP_START_ADDRESS as usize
+    + solana_program::entrypoint::HEAP_LENGTH;
+
+impl BumpAllocator {
+    /// Resets the allocation cursor. Must run before the first allocation, so
+    /// [`entrypoint!`] calls it first thing.
+    ///
+    /// # Safety
+    ///
+    /// Only valid on the Solana target where the heap region exists.
+    #[inline(always)]
+    pub unsafe fn init() {
+        *HEAP_CURSOR = HEAP_BOTTOM;
+    }
+}
+
+unsafe impl GlobalAlloc for BumpAllocator {
+    #[inline(always)]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let start: usize = (*HEAP_CURSOR).wrapping_add(layout.align() - 1) & !(layout.align() - 1);
+        // `start` is a heap address (< 2^35) and `Layout` sizes are at most
+        // `isize::MAX`, so this cannot wrap.
+        let end: usize = start.wrapping_add(layout.size());
+        if end > HEAP_TOP {
+            return null_mut();
+        }
+        *HEAP_CURSOR = end;
+        start as *mut u8
+    }
+
+    #[inline(always)]
+    unsafe fn dealloc(&self, _: *mut u8, _: Layout) {
+        // Bump allocator: never frees.
+    }
+}
+
+/// Deserializes the runtime input buffer at `input` and runs
+/// `process_instruction` on it, returning the runtime status code.
+///
+/// # Safety
+///
+/// `input` must be the buffer the runtime hands to the program `entrypoint`.
+#[inline(always)]
+pub unsafe fn process_entrypoint(input: *mut u8, process_instruction: ProcessInstruction) -> u64 {
+    let num_accounts: usize = *(input as *const u64) as usize;
+    if num_accounts > MAX_ACCOUNTS {
+        return process_entrypoint_on_heap(input, process_instruction);
+    }
+
+    let mut accounts: [MaybeUninit<AccountInfo>; MAX_ACCOUNTS] =
+        [const { MaybeUninit::<AccountInfo>::uninit() }; MAX_ACCOUNTS];
+    let (program_id, instruction_data) =
+        deserialize(input.add(size_of::<u64>()), num_accounts, &mut accounts);
+    let accounts: &[AccountInfo] =
+        from_raw_parts(accounts.as_ptr() as *const AccountInfo, num_accounts);
+
+    call_process_instruction(program_id, accounts, instruction_data, process_instruction)
+}
+
+/// Kept out of line so the account array above does not share a stack frame
+/// with the instruction processors.
+#[inline(never)]
+fn call_process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+    process_instruction: ProcessInstruction,
+) -> u64 {
+    match process_instruction(program_id, accounts, instruction_data) {
+        Ok(()) => solana_program::entrypoint::SUCCESS,
+        Err(error) => error.into(),
+    }
+}
+
+/// Stock `Vec` based deserialization, used only when an instruction carries
+/// more than [`MAX_ACCOUNTS`] accounts.
+#[cold]
+#[inline(never)]
+unsafe fn process_entrypoint_on_heap(
+    input: *mut u8,
+    process_instruction: ProcessInstruction,
+) -> u64 {
+    let (program_id, accounts, instruction_data) = solana_program::entrypoint::deserialize(input);
+    match process_instruction(program_id, &accounts, instruction_data) {
+        Ok(()) => solana_program::entrypoint::SUCCESS,
+        Err(error) => error.into(),
+    }
+}
+
+/// Decodes `num_accounts` accounts starting at `input` (which must point just
+/// past the leading account count) into `accounts`, then returns the program
+/// id and instruction data that follow them.
+///
+/// # Safety
+///
+/// `input` must point into the runtime input buffer at the first account and
+/// `num_accounts` must not exceed `accounts.len()`.
+#[inline(always)]
+unsafe fn deserialize<'a>(
+    mut input: *mut u8,
+    num_accounts: usize,
+    accounts: &mut [MaybeUninit<AccountInfo<'a>>; MAX_ACCOUNTS],
+) -> (&'a Pubkey, &'a [u8]) {
+    // Three shapes taken from zero-copy deserializers were measured here and
+    // not kept, so that nobody has to run the experiment again:
+    //
+    // * Peeling the first account out of the loop, which is sound because a
+    //   duplicate marker always names an earlier account, is worth 2 CU per
+    //   instruction. That does not pay for duplicating the account reading
+    //   body, and doing it with a flag tested in the loop instead costs 1.5
+    //   CU per account.
+    // * Replacing `align_offset` below with `(ptr + 7) & !7` costs 7 CU per
+    //   account: the integer round trip generates worse code than the pointer
+    //   intrinsic on SBPF.
+    // * Unrolling the loop cannot be worth much either, since peeling showed
+    //   the whole per-iteration bookkeeping is about 2 CU.
+    let first: *mut AccountInfo<'a> = accounts.as_mut_ptr() as *mut AccountInfo<'a>;
+    let end: *mut AccountInfo<'a> = first.add(num_accounts);
+    let mut dst: *mut AccountInfo<'a> = first;
+
+    while dst != end {
+        let account: *mut RuntimeAccount = input as *mut RuntimeAccount;
+        let dup_info: u8 = (*account).dup_info;
+        if dup_info == NON_DUP_MARKER {
+            let data_len: usize = (*account).data_len as usize;
+            (*account).original_data_len = data_len as u32;
+            let data: *mut u8 = input.add(size_of::<RuntimeAccount>());
+
+            // Each field is written as soon as it is decoded so that few
+            // values are live at once (the SBF target has 10 registers). The
+            // runtime serializes the three flags as 0 or 1; masking keeps the
+            // conversion branchless, which is 9 CU per account cheaper than
+            // `!= 0`.
+            addr_of_mut!((*dst).key).write(&(*account).key);
+            addr_of_mut!((*dst).owner).write(&(*account).owner);
+            addr_of_mut!((*dst).is_signer).write(((*account).is_signer & 1) != 0);
+            addr_of_mut!((*dst).is_writable).write(((*account).is_writable & 1) != 0);
+            // Nothing in these programs reads `executable`, and writing a
+            // constant `false` here instead of reading it measures 2 CU per
+            // account cheaper. Not taken: the flag would then be wrong in
+            // every `AccountInfo` the program hands out, including the array
+            // the runtime translates when one of them is passed to a CPI, and
+            // 2 CU per account does not buy that.
+            addr_of_mut!((*dst).executable).write(((*account).executable & 1) != 0);
+            addr_of_mut!((*dst).lamports).write(Rc::new(RefCell::new(&mut *addr_of_mut!(
+                (*account).lamports
+            ))));
+            addr_of_mut!((*dst).data)
+                .write(Rc::new(RefCell::new(from_raw_parts_mut(data, data_len))));
+
+            // Skip the data, the realloc padding, alignment and the rent epoch.
+            input = data.add(data_len).add(MAX_PERMITTED_DATA_INCREASE);
+            input = input.add(input.align_offset(BPF_ALIGN_OF_U128));
+            addr_of_mut!((*dst).rent_epoch).write(*(input as *const u64));
+            input = input.add(size_of::<u64>());
+        } else {
+            // Duplicate: one marker byte plus seven bytes of padding, and the
+            // `AccountInfo` shares the `Rc`s of the account it duplicates.
+            input = input.add(size_of::<u64>());
+            dst.write((*first.add(dup_info as usize)).clone());
+        }
+        dst = dst.add(1);
+    }
+
+    let instruction_data_len: usize = *(input as *const u64) as usize;
+    input = input.add(size_of::<u64>());
+    let instruction_data: &[u8] = from_raw_parts(input, instruction_data_len);
+    let program_id: &Pubkey = &*(input.add(instruction_data_len) as *const Pubkey);
+
+    (program_id, instruction_data)
+}

--- a/programs/manifest/src/lib.rs
+++ b/programs/manifest/src/lib.rs
@@ -1,6 +1,7 @@
 //! Manifest is a limit order book exchange on the Solana blockchain.
 //!
 
+pub mod entrypoint;
 pub mod logs;
 pub mod program;
 pub mod quantities;
@@ -96,7 +97,7 @@ security_txt! {
 declare_id!("MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms");
 
 #[cfg(not(feature = "no-entrypoint"))]
-solana_program::entrypoint!(process_instruction);
+crate::entrypoint!(process_instruction);
 
 pub fn process_instruction(
     program_id: &Pubkey,

--- a/programs/manifest/tests/cases/cu.rs
+++ b/programs/manifest/tests/cases/cu.rs
@@ -1,0 +1,589 @@
+//! Compute unit measurements for each instruction.
+//!
+//! Every test simulates a representative transaction, prints a line of the
+//! form `CU <name>: <units>` and then executes it. The numbers are only
+//! meaningful when the compiled BPF program is loaded
+//! (`cargo test-sbf --features "test,test-sbf"`); the native processor used by
+//! plain `cargo test` does not meter compute, but the tests still exercise the
+//! same instructions there.
+//!
+//! The program derives its vault and global PDAs on chain with
+//! `find_program_address`, which costs about 1,500 CU per bump it has to try.
+//! So that the numbers do not vary with the random test keys, markets and
+//! mints are created with keys whose PDAs derive on the first bump.
+//!
+//! No test asserts a specific number, they exist so different builds of the
+//! program can be compared line by line.
+
+use std::{cell::RefMut, rc::Rc};
+
+use manifest::{
+    program::{
+        batch_update::{CancelOrderParams, PlaceOrderParams},
+        batch_update_instruction, claim_seat_instruction, create_global_instruction,
+        create_market_instructions, deposit_instruction, expand_market_instruction,
+        global_add_trader_instruction, global_deposit_instruction, global_withdraw_instruction,
+        swap_instruction, withdraw_instruction,
+    },
+    state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, OrderType},
+    validation::{get_global_address, get_global_vault_address, get_vault_address},
+};
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_program::{program_pack::Pack, pubkey::Pubkey, rent::Rent, system_instruction};
+use solana_program_test::{tokio, ProgramTestContext};
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+use crate::{send_tx_with_retry, TestFixture, TokenAccountFixture, SOL_UNIT_SIZE, USDC_UNIT_SIZE};
+
+/// Simulates `instructions` and returns the transaction result together with
+/// the compute units the simulation consumed.
+async fn simulate(
+    test_fixture: &TestFixture,
+    instructions: &[Instruction],
+    payer: &Pubkey,
+    signers: &[&Keypair],
+) -> (Result<(), String>, u64) {
+    let mut context: RefMut<ProgramTestContext> = test_fixture.context.borrow_mut();
+    let blockhash: solana_program::hash::Hash = context.get_new_latest_blockhash().await.unwrap();
+    let transaction: Transaction =
+        Transaction::new_signed_with_payer(instructions, Some(payer), signers, blockhash);
+    let simulation = context
+        .banks_client
+        .simulate_transaction(transaction)
+        .await
+        .unwrap();
+    let units_consumed: u64 = simulation
+        .simulation_details
+        .expect("simulation details present")
+        .units_consumed;
+    let result: Result<(), String> = match simulation.result {
+        Some(Err(error)) => Err(format!("{error:?}")),
+        _ => Ok(()),
+    };
+    (result, units_consumed)
+}
+
+/// Simulates `instructions`, requiring success, prints the compute units as
+/// `CU <name>: <units>` and then executes the transaction so that later
+/// measurements in the same test see its effects.
+async fn measure_and_send(
+    test_fixture: &TestFixture,
+    name: &str,
+    instructions: &[Instruction],
+    payer: &Pubkey,
+    signers: &[&Keypair],
+) -> anyhow::Result<u64> {
+    let (result, units_consumed) = simulate(test_fixture, instructions, payer, signers).await;
+    if let Err(error) = result {
+        panic!("{name} simulation failed: {error}");
+    }
+    println!("CU {name}: {units_consumed}");
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        instructions,
+        Some(payer),
+        signers,
+    )
+    .await?;
+    Ok(units_consumed)
+}
+
+/// A market keypair whose base and quote vault PDAs derive on the first bump.
+fn market_keypair_with_first_bump_vaults(base_mint: &Pubkey, quote_mint: &Pubkey) -> Keypair {
+    loop {
+        let keypair: Keypair = Keypair::new();
+        let (_, base_bump) = get_vault_address(&keypair.pubkey(), base_mint);
+        let (_, quote_bump) = get_vault_address(&keypair.pubkey(), quote_mint);
+        if base_bump == u8::MAX && quote_bump == u8::MAX {
+            return keypair;
+        }
+    }
+}
+
+/// A mint keypair whose global and global vault PDAs derive on the first bump.
+fn mint_keypair_with_first_bump_globals() -> Keypair {
+    loop {
+        let keypair: Keypair = Keypair::new();
+        let (_, global_bump) = get_global_address(&keypair.pubkey());
+        let (_, global_vault_bump) = get_global_vault_address(&keypair.pubkey());
+        if global_bump == u8::MAX && global_vault_bump == u8::MAX {
+            return keypair;
+        }
+    }
+}
+
+/// Creates a market on the fixture's SOL/USDC mints whose vault PDAs derive on
+/// the first bump, returning its key.
+async fn create_market_with_first_bump_vaults(
+    test_fixture: &TestFixture,
+) -> anyhow::Result<Pubkey> {
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let market_keypair: Keypair = market_keypair_with_first_bump_vaults(
+        &test_fixture.sol_mint_fixture.key,
+        &test_fixture.usdc_mint_fixture.key,
+    );
+    let create_market_ixs: Vec<Instruction> = create_market_instructions(
+        &market_keypair.pubkey(),
+        &test_fixture.sol_mint_fixture.key,
+        &test_fixture.usdc_mint_fixture.key,
+        &payer,
+    )?;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &create_market_ixs,
+        Some(&payer),
+        &[&payer_keypair, &market_keypair],
+    )
+    .await?;
+    Ok(market_keypair.pubkey())
+}
+
+/// Cost of just reaching the dispatcher: an instruction with an unknown tag is
+/// rejected before any account is touched, so all that is metered is the
+/// entrypoint deserialization for the given number of accounts (plus the
+/// dispatch). Measured for a range of account counts to expose the per-account
+/// cost.
+#[tokio::test]
+async fn cu_entrypoint_only_test() -> anyhow::Result<()> {
+    let test_fixture: TestFixture = TestFixture::new().await;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+
+    for num_extra_accounts in [0usize, 1, 2, 4, 8, 12, 16] {
+        let mut accounts: Vec<AccountMeta> = vec![AccountMeta::new(payer, true)];
+        for _ in 0..num_extra_accounts {
+            accounts.push(AccountMeta::new_readonly(Pubkey::new_unique(), false));
+        }
+        let unknown_instruction: Instruction = Instruction {
+            program_id: manifest::id(),
+            accounts,
+            data: vec![u8::MAX],
+        };
+        let (result, units_consumed) = simulate(
+            &test_fixture,
+            &[unknown_instruction],
+            &payer,
+            &[&payer_keypair],
+        )
+        .await;
+        assert!(result.is_err(), "unknown instruction tag must be rejected");
+        println!(
+            "CU entrypoint_only[{} accounts]: {}",
+            1 + num_extra_accounts,
+            units_consumed
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn cu_create_market_test() -> anyhow::Result<()> {
+    let test_fixture: TestFixture = TestFixture::new().await;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let market_keypair: Keypair = market_keypair_with_first_bump_vaults(
+        &test_fixture.sol_mint_fixture.key,
+        &test_fixture.usdc_mint_fixture.key,
+    );
+
+    let create_market_ixs: Vec<Instruction> = create_market_instructions(
+        &market_keypair.pubkey(),
+        &test_fixture.sol_mint_fixture.key,
+        &test_fixture.usdc_mint_fixture.key,
+        &payer,
+    )?;
+    // Includes the system program create account instruction.
+    measure_and_send(
+        &test_fixture,
+        "create_market",
+        &create_market_ixs,
+        &payer,
+        &[&payer_keypair, &market_keypair],
+    )
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cu_claim_seat_and_expand_test() -> anyhow::Result<()> {
+    let test_fixture: TestFixture = TestFixture::new().await;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let market: Pubkey = create_market_with_first_bump_vaults(&test_fixture).await?;
+
+    measure_and_send(
+        &test_fixture,
+        "claim_seat",
+        &[claim_seat_instruction(&market, &payer)],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    measure_and_send(
+        &test_fixture,
+        "expand_market",
+        &[expand_market_instruction(&market, &payer)],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cu_deposit_and_withdraw_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let market: Pubkey = create_market_with_first_bump_vaults(&test_fixture).await?;
+    let amount_atoms: u64 = 10 * SOL_UNIT_SIZE;
+
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[claim_seat_instruction(&market, &payer)],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    test_fixture
+        .sol_mint_fixture
+        .mint_to(&test_fixture.payer_sol_fixture.key, amount_atoms)
+        .await;
+
+    measure_and_send(
+        &test_fixture,
+        "deposit",
+        &[deposit_instruction(
+            &market,
+            &payer,
+            &test_fixture.sol_mint_fixture.key,
+            amount_atoms,
+            &test_fixture.payer_sol_fixture.key,
+            spl_token::id(),
+            None,
+        )],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    measure_and_send(
+        &test_fixture,
+        "withdraw",
+        &[withdraw_instruction(
+            &market,
+            &payer,
+            &test_fixture.sol_mint_fixture.key,
+            amount_atoms,
+            &test_fixture.payer_sol_fixture.key,
+            spl_token::id(),
+            None,
+        )],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cu_place_and_cancel_order_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let market: Pubkey = create_market_with_first_bump_vaults(&test_fixture).await?;
+    let deposit_atoms: u64 = 10 * SOL_UNIT_SIZE;
+
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[claim_seat_instruction(&market, &payer)],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    test_fixture
+        .sol_mint_fixture
+        .mint_to(&test_fixture.payer_sol_fixture.key, deposit_atoms)
+        .await;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[deposit_instruction(
+            &market,
+            &payer,
+            &test_fixture.sol_mint_fixture.key,
+            deposit_atoms,
+            &test_fixture.payer_sol_fixture.key,
+            spl_token::id(),
+            None,
+        )],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    // Resting ask, 1 SOL at 1 USDC (price = 1e-3 quote atoms per base atom).
+    let place_order_ix: Instruction = batch_update_instruction(
+        &market,
+        &payer,
+        None,
+        vec![],
+        vec![PlaceOrderParams::new(
+            1 * SOL_UNIT_SIZE,
+            1,
+            -3,
+            false,
+            OrderType::Limit,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+        )],
+        None,
+        None,
+        None,
+        None,
+    );
+    measure_and_send(
+        &test_fixture,
+        "batch_update_place_1",
+        &[place_order_ix],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+
+    // Five more asks at distinct prices in one instruction.
+    let orders: Vec<PlaceOrderParams> = (2..7)
+        .map(|price_mantissa: u32| {
+            PlaceOrderParams::new(
+                1 * SOL_UNIT_SIZE,
+                price_mantissa,
+                -3,
+                false,
+                OrderType::Limit,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )
+        })
+        .collect();
+    let place_orders_ix: Instruction = batch_update_instruction(
+        &market,
+        &payer,
+        None,
+        vec![],
+        orders,
+        None,
+        None,
+        None,
+        None,
+    );
+    measure_and_send(
+        &test_fixture,
+        "batch_update_place_5",
+        &[place_orders_ix],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+
+    // The first order placed on a fresh market has sequence number 0.
+    let cancel_order_ix: Instruction = batch_update_instruction(
+        &market,
+        &payer,
+        None,
+        vec![CancelOrderParams::new(0)],
+        vec![],
+        None,
+        None,
+        None,
+        None,
+    );
+    measure_and_send(
+        &test_fixture,
+        "batch_update_cancel_1",
+        &[cancel_order_ix],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cu_swap_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let market: Pubkey = create_market_with_first_bump_vaults(&test_fixture).await?;
+    let deposit_atoms: u64 = 10 * SOL_UNIT_SIZE;
+
+    // Maker: seat, deposit and a resting ask of 1 SOL at 1 USDC.
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[claim_seat_instruction(&market, &payer)],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    test_fixture
+        .sol_mint_fixture
+        .mint_to(&test_fixture.payer_sol_fixture.key, deposit_atoms)
+        .await;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            deposit_instruction(
+                &market,
+                &payer,
+                &test_fixture.sol_mint_fixture.key,
+                deposit_atoms,
+                &test_fixture.payer_sol_fixture.key,
+                spl_token::id(),
+                None,
+            ),
+            batch_update_instruction(
+                &market,
+                &payer,
+                None,
+                vec![],
+                vec![PlaceOrderParams::new(
+                    1 * SOL_UNIT_SIZE,
+                    1,
+                    -3,
+                    false,
+                    OrderType::Limit,
+                    NO_EXPIRATION_LAST_VALID_SLOT,
+                )],
+                None,
+                None,
+                None,
+                None,
+            ),
+        ],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    // Taker buys 1 SOL with 1 USDC from the wallet, filling the single ask.
+    let quote_in_atoms: u64 = 1 * USDC_UNIT_SIZE;
+    test_fixture
+        .usdc_mint_fixture
+        .mint_to(&test_fixture.payer_usdc_fixture.key, quote_in_atoms)
+        .await;
+    let swap_ix: Instruction = swap_instruction(
+        &market,
+        &payer,
+        &test_fixture.sol_mint_fixture.key,
+        &test_fixture.usdc_mint_fixture.key,
+        &test_fixture.payer_sol_fixture.key,
+        &test_fixture.payer_usdc_fixture.key,
+        quote_in_atoms,
+        1 * SOL_UNIT_SIZE,
+        false,
+        true,
+        spl_token::id(),
+        spl_token::id(),
+        false,
+    );
+    measure_and_send(
+        &test_fixture,
+        "swap_fill_1",
+        &[swap_ix],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cu_global_test() -> anyhow::Result<()> {
+    let test_fixture: TestFixture = TestFixture::new().await;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let amount_atoms: u64 = 10 * USDC_UNIT_SIZE;
+
+    // A mint whose global PDAs derive on the first bump, with the payer as its
+    // mint authority, and a token account for the payer.
+    let mint_keypair: Keypair = mint_keypair_with_first_bump_globals();
+    let mint: Pubkey = mint_keypair.pubkey();
+    let rent: Rent = test_fixture
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_rent()
+        .await?;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            system_instruction::create_account(
+                &payer,
+                &mint,
+                rent.minimum_balance(spl_token::state::Mint::LEN),
+                spl_token::state::Mint::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_mint(&spl_token::id(), &mint, &payer, None, 6)?,
+        ],
+        Some(&payer),
+        &[&payer_keypair, &mint_keypair],
+    )
+    .await?;
+    let token_account: TokenAccountFixture =
+        TokenAccountFixture::new(Rc::clone(&test_fixture.context), &mint, &payer).await;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            spl_token::instruction::mint_to(
+                &spl_token::id(),
+                &mint,
+                &token_account.key,
+                &payer,
+                &[&payer],
+                amount_atoms,
+            )?,
+            create_global_instruction(&mint, &payer, &spl_token::id()),
+        ],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    let (global, _) = get_global_address(&mint);
+    measure_and_send(
+        &test_fixture,
+        "global_add_trader",
+        &[global_add_trader_instruction(&global, &payer)],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    measure_and_send(
+        &test_fixture,
+        "global_deposit",
+        &[global_deposit_instruction(
+            &mint,
+            &payer,
+            &token_account.key,
+            &spl_token::id(),
+            amount_atoms,
+        )],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    measure_and_send(
+        &test_fixture,
+        "global_withdraw",
+        &[global_withdraw_instruction(
+            &mint,
+            &payer,
+            &token_account.key,
+            &spl_token::id(),
+            amount_atoms,
+        )],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await?;
+    Ok(())
+}

--- a/programs/manifest/tests/cases/mod.rs
+++ b/programs/manifest/tests/cases/mod.rs
@@ -2,6 +2,7 @@ pub mod batch_update;
 pub mod cancel_order;
 pub mod claim_seat;
 pub mod create_market;
+pub mod cu;
 pub mod deposit;
 pub mod exploit_global_clean;
 pub mod exploit_global_reduce;

--- a/programs/ui-wrapper/src/lib.rs
+++ b/programs/ui-wrapper/src/lib.rs
@@ -38,7 +38,7 @@ security_txt! {
 declare_id!("UMnFStVeG1ecZFc2gc5K3vFy3sMpotq8C91mXBQDGwh");
 
 #[cfg(not(feature = "no-entrypoint"))]
-solana_program::entrypoint!(process_instruction);
+manifest::entrypoint!(process_instruction);
 
 pub fn process_instruction(
     program_id: &Pubkey,

--- a/programs/wrapper/src/lib.rs
+++ b/programs/wrapper/src/lib.rs
@@ -37,7 +37,7 @@ security_txt! {
 declare_id!("wMNFSTkir3HgyZTsB7uqu3i7FA73grFCptPXgrZjksL");
 
 #[cfg(not(feature = "no-entrypoint"))]
-solana_program::entrypoint!(process_instruction);
+manifest::entrypoint!(process_instruction);
 
 pub fn process_instruction(
     program_id: &Pubkey,


### PR DESCRIPTION
solana_program::entrypoint! copies every account into a Vec<AccountInfo> through a generic deserializer and installs the default allocator. On SBPF v2 that costs about 464 CU plus 280 per account before the program does anything, which for a five account instruction is 1,864 CU of the budget spent on parsing.

Write the input parsing directly instead: walk the runtime's serialized accounts once, build the AccountInfo array in place with a running pointer, and keep the layout assumptions (original_data_len for realloc, the duplicate marker, the flags byte) in one place. Fall back to the stock deserializer above 64 accounts, which no instruction reaches. The allocator becomes a bump allocator over the heap.

Now about 185 CU plus 72 per account, so roughly 545 CU on a five account instruction. All three programs use it.

Adds tests/cases/cu.rs, which measures every instruction and prints the numbers so that two builds can be compared line by line. It asserts no absolute values; markets and mints there are created with keys whose PDAs derive on the first bump so the numbers do not move with the random test keys.