### PR TITLE
Cache the canonical global accounts on the market

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,6 +2708,7 @@ dependencies = [
 name = "manifest-client"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "hypertree",
  "manifest-dex",
  "solana-instruction",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,6 +2744,7 @@ dependencies = [
  "solana-account",
  "solana-clock",
  "solana-compute-budget-interface",
+ "solana-curve25519",
  "solana-instruction",
  "solana-invoke",
  "solana-keypair",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0.66"
 solana-security-txt = "=1.1.2"
 static_assertions = "=1.1.0"
 solana-invoke = "=0.4.0"
+solana-curve25519 = "=2.2.4"
 
 anyhow = "1.0.66"
 solana-program-test = "=2.2.4"

--- a/client/idl/manifest.json
+++ b/client/idl/manifest.json
@@ -2020,13 +2020,12 @@
             "type": "u64"
           },
           {
-            "name": "padding3",
-            "type": {
-              "array": [
-                "u64",
-                8
-              ]
-            }
+            "name": "baseGlobal",
+            "type": "publicKey"
+          },
+          {
+            "name": "quoteGlobal",
+            "type": "publicKey"
           }
         ]
       }

--- a/client/rust/slim/Cargo.toml
+++ b/client/rust/slim/Cargo.toml
@@ -25,6 +25,7 @@ solana-keypair = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 manifest-dex = { path = "../../../programs/manifest" }
+bytemuck = { workspace = true }
 spl-token = { workspace = true }
 spl-token-2022 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/client/rust/slim/src/state.rs
+++ b/client/rust/slim/src/state.rs
@@ -50,19 +50,19 @@ pub struct MarketFixed {
     /// Red-black tree root representing the seats
     pub claimed_seats_root_index: DataIndex,
 
-    /// Cached best claimed seat. This is presently unused by the client, but
-    /// retained so the following fields match the on-chain account layout.
-    pub claimed_seats_best_index: DataIndex,
-
     /// LinkedList representing all free blocks
     pub free_list_head_index: DataIndex,
 
-    pub _padding2: [u64; 1],
+    pub _padding2: [u32; 1],
 
     /// Quote volume traded over lifetime, can overflow.
     pub quote_volume: u64,
 
-    pub _padding3: [u64; 7],
+    /// Canonical global account for the base mint, cached by the program.
+    /// All zero on markets that have not traded against a global yet.
+    pub base_global: [u8; 32],
+    /// Canonical global account for the quote mint, see `base_global`.
+    pub quote_global: [u8; 32],
 }
 
 impl MarketFixed {
@@ -106,6 +106,20 @@ impl MarketFixed {
     /// Check if there's a free block available.
     pub fn has_free_block(&self) -> bool {
         self.free_list_head_index != NIL
+    }
+
+    /// Get the cached canonical global account for the base mint, or `None`
+    /// when the program has not cached it for this market yet.
+    pub fn get_base_global(&self) -> Option<Pubkey> {
+        let key: Pubkey = Pubkey::from(self.base_global);
+        (key != Pubkey::default()).then_some(key)
+    }
+
+    /// Get the cached canonical global account for the quote mint, see
+    /// `get_base_global`.
+    pub fn get_quote_global(&self) -> Option<Pubkey> {
+        let key: Pubkey = Pubkey::from(self.quote_global);
+        (key != Pubkey::default()).then_some(key)
     }
 }
 

--- a/client/rust/slim/tests/market_fixed_layout.rs
+++ b/client/rust/slim/tests/market_fixed_layout.rs
@@ -11,8 +11,7 @@
 //! distinguishable and reading it back through the slim definition.
 
 use bytemuck::Zeroable;
-use manifest::quantities::WrapperU64;
-use manifest::state::MarketFixed as CoreMarketFixed;
+use manifest::{quantities::WrapperU64, state::MarketFixed as CoreMarketFixed};
 use manifest_client::{MarketFixed as SlimMarketFixed, MARKET_FIXED_DISCRIMINANT};
 use solana_pubkey::Pubkey;
 

--- a/client/rust/slim/tests/market_fixed_layout.rs
+++ b/client/rust/slim/tests/market_fixed_layout.rs
@@ -1,0 +1,101 @@
+//! The slim client re-declares `MarketFixed` so that it does not have to
+//! depend on the program crate. Nothing makes the two definitions agree, and
+//! when they drift the account still parses, because the size and the
+//! discriminant are unchanged, while every field after the drift silently
+//! reads the wrong bytes. That has happened: a field that only ever existed
+//! in a stale size comment was added here, which moved `free_list_head_index`
+//! by four bytes and `quote_volume` by eight.
+//!
+//! These tests pin the two layouts together by filling a program
+//! `MarketFixed` with a pattern that makes every byte position
+//! distinguishable and reading it back through the slim definition.
+
+use bytemuck::Zeroable;
+use manifest::quantities::WrapperU64;
+use manifest::state::MarketFixed as CoreMarketFixed;
+use manifest_client::{MarketFixed as SlimMarketFixed, MARKET_FIXED_DISCRIMINANT};
+use solana_pubkey::Pubkey;
+
+/// A program `MarketFixed` whose bytes are all distinct, so that a field read
+/// at the wrong offset cannot coincidentally match.
+fn patterned_core_fixed() -> CoreMarketFixed {
+    let mut fixed: CoreMarketFixed = CoreMarketFixed::zeroed();
+    for (i, byte) in bytemuck::bytes_of_mut(&mut fixed).iter_mut().enumerate() {
+        // Never zero, so that an unset field is distinguishable from a set one.
+        *byte = (i as u8) | 1;
+    }
+    fixed.discriminant = MARKET_FIXED_DISCRIMINANT;
+    fixed.set_base_global(Pubkey::new_from_array([7_u8; 32]));
+    fixed.set_quote_global(Pubkey::new_from_array([9_u8; 32]));
+    fixed
+}
+
+#[test]
+fn slim_market_fixed_matches_the_program_layout() {
+    assert_eq!(
+        std::mem::size_of::<SlimMarketFixed>(),
+        std::mem::size_of::<CoreMarketFixed>(),
+        "the two MarketFixed definitions must stay the same size",
+    );
+
+    let core: CoreMarketFixed = patterned_core_fixed();
+    let slim: SlimMarketFixed = SlimMarketFixed::try_from_bytes(bytemuck::bytes_of(&core))
+        .expect("slim parses a program market header");
+
+    assert_eq!(slim.get_base_mint(), *core.get_base_mint(), "base_mint");
+    assert_eq!(slim.get_quote_mint(), *core.get_quote_mint(), "quote_mint");
+    assert_eq!(slim.get_base_vault(), *core.get_base_vault(), "base_vault");
+    assert_eq!(
+        slim.get_quote_vault(),
+        *core.get_quote_vault(),
+        "quote_vault"
+    );
+    assert_eq!(
+        slim.base_mint_decimals,
+        core.get_base_mint_decimals(),
+        "base_mint_decimals",
+    );
+    assert_eq!(
+        slim.quote_mint_decimals,
+        core.get_quote_mint_decimals(),
+        "quote_mint_decimals",
+    );
+    assert_eq!(
+        slim.base_vault_bump,
+        core.get_base_vault_bump(),
+        "base_vault_bump",
+    );
+    assert_eq!(
+        slim.quote_vault_bump,
+        core.get_quote_vault_bump(),
+        "quote_vault_bump",
+    );
+    // The field the last drift moved. Everything between the tree indices and
+    // this one is pinned by it: an extra or resized field before it shifts
+    // this read.
+    assert_eq!(
+        slim.quote_volume,
+        core.get_quote_volume().as_u64(),
+        "quote_volume",
+    );
+    assert_eq!(
+        slim.get_base_global(),
+        Some(*core.get_base_global()),
+        "base_global",
+    );
+    assert_eq!(
+        slim.get_quote_global(),
+        Some(*core.get_quote_global()),
+        "quote_global",
+    );
+}
+
+#[test]
+fn slim_reports_no_cached_globals_on_an_old_market() {
+    let mut core: CoreMarketFixed = CoreMarketFixed::zeroed();
+    core.discriminant = MARKET_FIXED_DISCRIMINANT;
+    let slim: SlimMarketFixed =
+        SlimMarketFixed::try_from_bytes(bytemuck::bytes_of(&core)).expect("slim parses");
+    assert_eq!(slim.get_base_global(), None, "base_global uncached");
+    assert_eq!(slim.get_quote_global(), None, "quote_global uncached");
+}

--- a/client/ts/src/manifest/types/MarketFixed.ts
+++ b/client/ts/src/manifest/types/MarketFixed.ts
@@ -30,7 +30,8 @@ export type MarketFixed = {
   freeListHeadIndex: number;
   padding2: number[] /* size: 1 */;
   quoteVolume: beet.bignum;
-  padding3: beet.bignum[] /* size: 8 */;
+  baseGlobal: web3.PublicKey;
+  quoteGlobal: web3.PublicKey;
 };
 
 /**
@@ -60,7 +61,8 @@ export const marketFixedBeet = new beet.BeetArgsStruct<MarketFixed>(
     ['freeListHeadIndex', beet.u32],
     ['padding2', beet.uniformFixedSizeArray(beet.u32, 1)],
     ['quoteVolume', beet.u64],
-    ['padding3', beet.uniformFixedSizeArray(beet.u64, 8)],
+    ['baseGlobal', beetSolana.publicKey],
+    ['quoteGlobal', beetSolana.publicKey],
   ],
   'MarketFixed',
 );

--- a/client/ts/src/market.ts
+++ b/client/ts/src/market.ts
@@ -737,7 +737,8 @@ export class Market {
     const quoteVolumeAtoms: bigint = data.readBigUInt64LE(offset);
     offset += 8;
 
-    // _padding3: [u64; 8],
+    // base_global: Pubkey, quote_global: Pubkey. Canonical global accounts
+    // cached by the program, zero until a market has traded with globals.
 
     const dynamicData: Buffer = data.subarray(FIXED_MANIFEST_HEADER_SIZE);
     const parseContext: RedBlackTreeParseContext =

--- a/programs/manifest/Cargo.toml
+++ b/programs/manifest/Cargo.toml
@@ -50,6 +50,7 @@ vectors = { workspace = true, optional = true}
 hook_macro = { workspace = true, optional = true}
 arrayref = { workspace = true}
 solana-invoke = { workspace = true }
+solana-curve25519 = { workspace = true }
 cvlr = { version = "0.4", optional = true } 
 
 [dev-dependencies]

--- a/programs/manifest/src/program/processor/create_market.rs
+++ b/programs/manifest/src/program/processor/create_market.rs
@@ -1,12 +1,14 @@
 use std::{cell::Ref, mem::size_of};
 
+#[cfg(not(feature = "certora"))]
+use crate::validation::get_global_address;
 use crate::{
     logs::{emit_stack, CreateMarketLog},
     program::{expand_market_if_needed, invoke},
     require,
     state::MarketFixed,
     utils::create_account,
-    validation::{get_vault_address, loaders::CreateMarketContext},
+    validation::loaders::CreateMarketContext,
 };
 use hypertree::{get_mut_helper, trace};
 use solana_program::{
@@ -37,6 +39,8 @@ pub(crate) fn process_create_market(
         quote_mint,
         base_vault,
         quote_vault,
+        base_vault_bump,
+        quote_vault_bump,
         system_program,
         token_program,
         token_program_22,
@@ -79,9 +83,9 @@ pub(crate) fn process_create_market(
     {
         // Create the base and quote vaults of this market
         let rent: Rent = Rent::get()?;
-        for (token_account, mint) in [
-            (base_vault.as_ref(), base_mint.as_ref()),
-            (quote_vault.as_ref(), quote_mint.as_ref()),
+        for (token_account, mint, bump) in [
+            (base_vault.as_ref(), base_mint.as_ref(), base_vault_bump),
+            (quote_vault.as_ref(), quote_mint.as_ref(), quote_vault_bump),
         ] {
             // We dont have to deserialize the mint, just check the owner.
             let is_mint_22: bool = *mint.owner == spl_token_2022::id();
@@ -91,7 +95,6 @@ pub(crate) fn process_create_market(
                 spl_token::id()
             };
 
-            let (_vault_key, bump) = get_vault_address(market.key, mint.key);
             let seeds: Vec<Vec<u8>> = vec![
                 b"vault".to_vec(),
                 market.key.as_ref().to_vec(),
@@ -169,8 +172,24 @@ pub(crate) fn process_create_market(
         // would use an inactive market when multiple exist.
 
         // Setup the empty market
-        let empty_market_fixed: MarketFixed =
-            MarketFixed::new_empty(&base_mint, &quote_mint, market.key);
+        #[allow(unused_mut)]
+        let mut empty_market_fixed: MarketFixed = MarketFixed::new_empty_with_vaults(
+            &base_mint,
+            &quote_mint,
+            *base_vault.info.key,
+            base_vault_bump,
+            *quote_vault.info.key,
+            quote_vault_bump,
+        );
+        // Cache the global account addresses so that global trades on this
+        // market never have to derive them.
+        #[cfg(not(feature = "certora"))]
+        {
+            let (base_global, _) = get_global_address(base_mint.info.key);
+            let (quote_global, _) = get_global_address(quote_mint.info.key);
+            empty_market_fixed.set_base_global(base_global);
+            empty_market_fixed.set_quote_global(quote_global);
+        }
         assert_eq!(market.data_len(), size_of::<MarketFixed>());
 
         let market_bytes: &mut [u8] = &mut market.try_borrow_mut_data()?[..];

--- a/programs/manifest/src/program/processor/global_create.rs
+++ b/programs/manifest/src/program/processor/global_create.rs
@@ -6,7 +6,7 @@ use crate::{
     program::invoke,
     state::GlobalFixed,
     utils::create_account,
-    validation::{get_global_address, get_global_vault_address, loaders::GlobalCreateContext},
+    validation::{get_global_vault_address, loaders::GlobalCreateContext},
 };
 use hypertree::{get_mut_helper, trace};
 use solana_program::{
@@ -35,11 +35,13 @@ pub(crate) fn process_global_create(
             global_mint,
             global_vault,
             token_program,
+            global_bump,
         } = global_create_context;
+        let (expected_global_vault_key, global_vault_bump) =
+            get_global_vault_address(global_mint.info.key);
 
         // Make the global account.
         {
-            let (_expected_global_key, global_bump) = get_global_address(global_mint.info.key);
             let global_seeds: Vec<Vec<u8>> = vec![
                 b"global".to_vec(),
                 global_mint.info.key.as_ref().to_vec(),
@@ -72,7 +74,12 @@ pub(crate) fn process_global_create(
             )?;
 
             // Setup the empty market
-            let empty_global_fixed: GlobalFixed = GlobalFixed::new_empty(&global_mint.as_ref().key);
+            let empty_global_fixed: GlobalFixed = GlobalFixed::new_empty_with_bumps(
+                global_mint.as_ref().key,
+                expected_global_vault_key,
+                global_vault_bump,
+                global_bump,
+            );
             assert_eq!(global.info.data_len(), size_of::<GlobalFixed>());
 
             let global_bytes: &mut [u8] = &mut global.info.try_borrow_mut_data()?[..];
@@ -91,8 +98,6 @@ pub(crate) fn process_global_create(
                 spl_token::id()
             };
 
-            let (expected_global_vault_key, global_vault_bump) =
-                get_global_vault_address(global_mint.info.key);
             let global_vault_seeds: Vec<Vec<u8>> = vec![
                 b"global-vault".to_vec(),
                 global_mint.info.key.as_ref().to_vec(),

--- a/programs/manifest/src/program/processor/global_evict.rs
+++ b/programs/manifest/src/program/processor/global_evict.rs
@@ -8,9 +8,7 @@ use solana_program::{program::invoke_signed, program_pack::Pack, rent::Rent, sys
 use spl_token::state::Account;
 
 #[cfg(not(feature = "certora"))]
-use crate::{
-    global_vault_seeds_with_bump, state::GAS_DEPOSIT_LAMPORTS, validation::get_global_vault_address,
-};
+use crate::{global_vault_seeds_with_bump, state::GAS_DEPOSIT_LAMPORTS};
 use crate::{
     logs::{emit_stack, GlobalDepositLog, GlobalEvictLog, GlobalWithdrawLog},
     program::get_mut_dynamic_account,
@@ -105,6 +103,7 @@ pub(crate) fn process_global_evict_core(
             &global_vault,
             &evictee_token,
             evictee_balance.into(),
+            global_dynamic_account.fixed.get_vault_bump(),
         )?;
 
         emit_stack(GlobalWithdrawLog {
@@ -220,9 +219,8 @@ fn spl_token_transfer_from_global_vault_to_evictee<'a, 'info>(
     global_vault: &TokenAccountInfo<'a, 'info>,
     evictee_token: &TokenAccountInfo<'a, 'info>,
     amount_atoms: u64,
+    bump: u8,
 ) -> ProgramResult {
-    let (_, bump) = get_global_vault_address(mint.info.key);
-
     if *global_vault.owner == spl_token_2022::id() {
         invoke_signed(
             &spl_token_2022::instruction::transfer_checked(
@@ -275,6 +273,7 @@ fn spl_token_transfer_from_global_vault_to_evictee<'a, 'info>(
     global_vault: &TokenAccountInfo<'a, 'info>,
     evictee_token: &TokenAccountInfo<'a, 'info>,
     amount_atoms: u64,
+    _bump: u8,
 ) -> ProgramResult {
     if *global_vault.owner == spl_token_2022::id() {
         spl_token_2022_transfer_with_fee(

--- a/programs/manifest/src/program/processor/global_withdraw.rs
+++ b/programs/manifest/src/program/processor/global_withdraw.rs
@@ -8,10 +8,7 @@ use crate::{
     program::get_mut_dynamic_account,
     quantities::{GlobalAtoms, WrapperU64},
     state::GlobalRefMut,
-    validation::{
-        get_global_vault_address, loaders::GlobalWithdrawContext, MintAccountInfo,
-        TokenAccountInfo, TokenProgram,
-    },
+    validation::{loaders::GlobalWithdrawContext, MintAccountInfo, TokenAccountInfo, TokenProgram},
 };
 
 #[cfg(not(feature = "certora"))]
@@ -69,7 +66,8 @@ pub(crate) fn process_global_withdraw_core(
     let mut global_dynamic_account: GlobalRefMut = get_mut_dynamic_account(global_data);
     global_dynamic_account.withdraw_global(payer.key, GlobalAtoms::new(amount_atoms))?;
 
-    let (_, bump) = get_global_vault_address(mint.info.key);
+    // Sign with the bump stored at creation instead of searching for it.
+    let bump: u8 = global_dynamic_account.fixed.get_vault_bump();
 
     // Do the token transfer
     if *global_vault.owner == spl_token_2022::id() {

--- a/programs/manifest/src/state/global.rs
+++ b/programs/manifest/src/state/global.rs
@@ -275,6 +275,16 @@ impl GlobalFixed {
     pub fn new_empty(mint: &Pubkey) -> Self {
         let (vault, vault_bump) = get_global_vault_address(mint);
         let (_, global_bump) = get_global_address(mint);
+        Self::new_empty_with_bumps(mint, vault, vault_bump, global_bump)
+    }
+
+    /// Like `new_empty` for a caller that has already derived the PDAs.
+    pub fn new_empty_with_bumps(
+        mint: &Pubkey,
+        vault: Pubkey,
+        vault_bump: u8,
+        global_bump: u8,
+    ) -> Self {
         GlobalFixed {
             discriminant: GLOBAL_FIXED_DISCRIMINANT,
             mint: *mint,
@@ -322,6 +332,9 @@ impl GlobalFixed {
     }
     pub fn get_vault_bump(&self) -> u8 {
         self.vault_bump
+    }
+    pub fn get_global_bump(&self) -> u8 {
+        self.global_bump
     }
     pub fn needs_eviction(&self) -> bool {
         self.num_seats_claimed >= MAX_GLOBAL_SEATS

--- a/programs/manifest/src/state/market.rs
+++ b/programs/manifest/src/state/market.rs
@@ -206,6 +206,14 @@ pub struct MarketFixed {
     /// search. All zero on markets created before this field existed (it was
     /// padding) until their first global batch update or swap derives and
     /// stores it.
+    ///
+    /// Neither this nor `quote_global` exists in the `certora` build. This
+    /// struct is 256 bytes either way, and that build already spends these
+    /// same 64 bytes on the informational atom totals below, which the specs
+    /// reason about. Verification therefore derives the address on every
+    /// check rather than reading a cache, which is also what lets the prover
+    /// state the property directly; see `verify_market_global`. Everything
+    /// else that touches these two fields is gated for the same reason.
     #[cfg(not(feature = "certora"))]
     base_global: Pubkey,
     /// Canonical global account for the quote mint, see `base_global`.
@@ -296,6 +304,9 @@ impl MarketFixed {
             free_list_head_index: 0,
             _padding2: [0; 1],
             quote_volume: QuoteAtoms::ZERO,
+            // The global cache does not exist under certora, see the field
+            // definitions; that build fills the same bytes with the totals
+            // below instead.
             #[cfg(not(feature = "certora"))]
             base_global: Pubkey::default(),
             #[cfg(not(feature = "certora"))]
@@ -356,6 +367,9 @@ impl MarketFixed {
     }
     /// Cached canonical global account for the base mint, or the default
     /// pubkey if it has not been derived for this market yet.
+    ///
+    /// These four accessors are gated only because the fields they read are:
+    /// the `certora` build has no global cache, see `base_global`.
     #[cfg(not(feature = "certora"))]
     pub fn get_base_global(&self) -> &Pubkey {
         &self.base_global

--- a/programs/manifest/src/state/market.rs
+++ b/programs/manifest/src/state/market.rs
@@ -201,11 +201,16 @@ pub struct MarketFixed {
     #[cfg(feature = "certora")]
     _padding3: [u64; 4],
 
-    // Unused padding. Saved in case a later version wants to be backwards
-    // compatible. Also, it is nice to have the fixed size be a round number,
-    // 256 bytes.
+    /// Canonical global account for the base mint, cached so that validating
+    /// the global accounts on a trade is a key compare instead of a PDA
+    /// search. All zero on markets created before this field existed (it was
+    /// padding) until their first global batch update or swap derives and
+    /// stores it.
     #[cfg(not(feature = "certora"))]
-    _padding3: [u64; 8],
+    base_global: Pubkey,
+    /// Canonical global account for the quote mint, see `base_global`.
+    #[cfg(not(feature = "certora"))]
+    quote_global: Pubkey,
 }
 const_assert_eq!(
     size_of::<MarketFixed>(),
@@ -230,7 +235,8 @@ const_assert_eq!(
     4 +   // claimed_seats_best_index
     4 +   // free_list_head_index
     8 +   // padding2
-    64 // padding4
+    32 +  // base_global
+    32 // quote_global
 );
 const_assert_eq!(size_of::<MarketFixed>(), MARKET_FIXED_SIZE);
 const_assert_eq!(size_of::<MarketFixed>() % 8, 0);
@@ -244,6 +250,26 @@ impl MarketFixed {
     ) -> Self {
         let (base_vault, base_vault_bump) = get_vault_address(market_key, base_mint.info.key);
         let (quote_vault, quote_vault_bump) = get_vault_address(market_key, quote_mint.info.key);
+        Self::new_empty_with_vaults(
+            base_mint,
+            quote_mint,
+            base_vault,
+            base_vault_bump,
+            quote_vault,
+            quote_vault_bump,
+        )
+    }
+
+    /// Like `new_empty` for a caller that has already derived the vault PDAs.
+    /// The global account cache starts empty, see `set_base_global`.
+    pub fn new_empty_with_vaults(
+        base_mint: &MintAccountInfo,
+        quote_mint: &MintAccountInfo,
+        base_vault: Pubkey,
+        base_vault_bump: u8,
+        quote_vault: Pubkey,
+        quote_vault_bump: u8,
+    ) -> Self {
         MarketFixed {
             discriminant: MARKET_FIXED_DISCRIMINANT,
             version: 0,
@@ -271,7 +297,9 @@ impl MarketFixed {
             _padding2: [0; 1],
             quote_volume: QuoteAtoms::ZERO,
             #[cfg(not(feature = "certora"))]
-            _padding3: [0; 8],
+            base_global: Pubkey::default(),
+            #[cfg(not(feature = "certora"))]
+            quote_global: Pubkey::default(),
             #[cfg(feature = "certora")]
             withdrawable_base_atoms: BaseAtoms::new(0),
             #[cfg(feature = "certora")]
@@ -325,6 +353,26 @@ impl MarketFixed {
     }
     pub fn get_quote_mint(&self) -> &Pubkey {
         &self.quote_mint
+    }
+    /// Cached canonical global account for the base mint, or the default
+    /// pubkey if it has not been derived for this market yet.
+    #[cfg(not(feature = "certora"))]
+    pub fn get_base_global(&self) -> &Pubkey {
+        &self.base_global
+    }
+    /// Cached canonical global account for the quote mint, or the default
+    /// pubkey if it has not been derived for this market yet.
+    #[cfg(not(feature = "certora"))]
+    pub fn get_quote_global(&self) -> &Pubkey {
+        &self.quote_global
+    }
+    #[cfg(not(feature = "certora"))]
+    pub fn set_base_global(&mut self, base_global: Pubkey) {
+        self.base_global = base_global;
+    }
+    #[cfg(not(feature = "certora"))]
+    pub fn set_quote_global(&mut self, quote_global: Pubkey) {
+        self.quote_global = quote_global;
     }
     pub fn get_base_vault(&self) -> &Pubkey {
         &self.base_vault

--- a/programs/manifest/src/validation/loaders.rs
+++ b/programs/manifest/src/validation/loaders.rs
@@ -3,9 +3,13 @@ use std::{
     slice::Iter,
 };
 
+#[cfg(not(feature = "certora"))]
+use hypertree::get_mut_helper;
+
 use hypertree::{get_helper, trace};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
     program_error::ProgramError,
     pubkey::Pubkey,
     system_program,
@@ -16,7 +20,8 @@ use crate::{
     require,
     state::{GlobalFixed, MarketFixed},
     validation::{
-        get_global_address, EmptyAccount, MintAccountInfo, Program, Signer, TokenAccountInfo,
+        get_global_address, is_global_address, EmptyAccount, MintAccountInfo, Program, Signer,
+        TokenAccountInfo,
     },
 };
 
@@ -33,6 +38,10 @@ pub(crate) struct CreateMarketContext<'a, 'info> {
     pub quote_mint: MintAccountInfo<'a, 'info>,
     pub base_vault: EmptyAccount<'a, 'info>,
     pub quote_vault: EmptyAccount<'a, 'info>,
+    /// Bumps of the vault PDAs, derived once here for signing and the market
+    /// header.
+    pub base_vault_bump: u8,
+    pub quote_vault_bump: u8,
     pub system_program: Program<'a, 'info>,
     pub token_program: TokenProgram<'a, 'info>,
     pub token_program_22: TokenProgram<'a, 'info>,
@@ -57,9 +66,9 @@ impl<'a, 'info> CreateMarketContext<'a, 'info> {
         let base_vault: EmptyAccount = EmptyAccount::new(next_account_info(account_iter)?)?;
         let quote_vault: EmptyAccount = EmptyAccount::new(next_account_info(account_iter)?)?;
 
-        let (expected_base_vault, _base_vault_bump) =
+        let (expected_base_vault, base_vault_bump) =
             get_vault_address(market.key, base_mint.info.key);
-        let (expected_quote_vault, _quote_vault_bump) =
+        let (expected_quote_vault, quote_vault_bump) =
             get_vault_address(market.key, quote_mint.info.key);
 
         require!(
@@ -80,6 +89,8 @@ impl<'a, 'info> CreateMarketContext<'a, 'info> {
             market,
             base_vault,
             quote_vault,
+            base_vault_bump,
+            quote_vault_bump,
             base_mint,
             quote_mint,
             token_program,
@@ -431,19 +442,6 @@ impl<'a, 'info> SwapContext<'a, 'info> {
                         &expected_global_vault_address,
                     )?;
 
-                // Assert that the global itself is at the expected address.
-                // This prevents an attack where the attacker maliciously makes
-                // an account and then assigns it to our program. They can make
-                // the discriminator and owner match, however they cannot put it
-                // at the correct address because that requires signing the PDA
-                // which only happens through our init.
-                let (expected_global_key, _global_bump) = get_global_address(global_mint_key);
-                require!(
-                    expected_global_key == *global.info.key,
-                    ManifestError::MissingGlobal,
-                    "Unexpected global accounts",
-                )?;
-
                 let index: usize = if *global_mint_key == base_mint_key {
                     0
                 } else {
@@ -454,6 +452,9 @@ impl<'a, 'info> SwapContext<'a, 'info> {
                     )?;
                     1
                 };
+                // Assert that the global itself is at the expected address,
+                // see `verify_market_global`.
+                verify_market_global(&market, index, global_mint_key, global.info.key)?;
 
                 drop(global_data);
                 global_trade_accounts_opts[index] = Some(GlobalTradeAccounts {
@@ -607,17 +608,12 @@ impl<'a, 'info> BatchUpdateContext<'a, 'info> {
                         continue;
                     }
                     let global: ManifestAccountInfo<'a, 'info, GlobalFixed> = global_or.unwrap();
+                    // Assert that the global itself is at the expected address,
+                    // see `verify_market_global`.
+                    verify_market_global(&market, index, mint.info.key, global.info.key)?;
                     let global_data: Ref<&mut [u8]> = global.data.borrow();
                     let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(&global_data, 0_u32);
                     let expected_global_vault_address: &Pubkey = global_fixed.get_vault();
-
-                    let global_mint_key: &Pubkey = global_fixed.get_mint();
-                    let (expected_global_key, _global_bump) = get_global_address(global_mint_key);
-                    require!(
-                        expected_global_key == *global.info.key,
-                        ManifestError::MissingGlobal,
-                        "Unexpected global accounts",
-                    )?;
 
                     let global_vault: TokenAccountInfo<'a, 'info> =
                         TokenAccountInfo::new_with_owner_and_key(
@@ -663,6 +659,74 @@ impl<'a, 'info> BatchUpdateContext<'a, 'info> {
     }
 }
 
+/// Verifies that `global_key` is the canonical global account for the
+/// market's base (`index` 0) or quote (`index` 1) mint, `mint`.
+///
+/// The canonical address is a program derived address, which is what makes
+/// the check meaningful: an attacker can create an account and assign it to
+/// this program, and even if they could make its owner and discriminant
+/// match, they cannot place it at the derived address because that needs the
+/// program's signature, which only its init provides. Deriving costs 1,500 CU
+/// per bump tried, so the address is derived once per market and side, stored
+/// on the market (`MarketFixed::get_base_global` / `get_quote_global`), and
+/// checked with a key compare from then on. Markets from before the cache
+/// existed have it filled in on their first global trade.
+#[cfg(not(feature = "certora"))]
+fn verify_market_global<'a, 'info>(
+    market: &ManifestAccountInfo<'a, 'info, MarketFixed>,
+    index: usize,
+    mint: &Pubkey,
+    global_key: &Pubkey,
+) -> ProgramResult {
+    let cached_global: Pubkey = {
+        let market_fixed: Ref<MarketFixed> = market.get_fixed()?;
+        if index == 0 {
+            *market_fixed.get_base_global()
+        } else {
+            *market_fixed.get_quote_global()
+        }
+    };
+    if cached_global != Pubkey::default() {
+        require!(
+            cached_global == *global_key,
+            ManifestError::MissingGlobal,
+            "Unexpected global accounts",
+        )?;
+        return Ok(());
+    }
+
+    let (expected_global_key, _global_bump) = get_global_address(mint);
+    require!(
+        expected_global_key == *global_key,
+        ManifestError::MissingGlobal,
+        "Unexpected global accounts",
+    )?;
+    let market_bytes: &mut [u8] = &mut market.try_borrow_mut_data()?[..];
+    let market_fixed: &mut MarketFixed = get_mut_helper::<MarketFixed>(market_bytes, 0_u32);
+    if index == 0 {
+        market_fixed.set_base_global(expected_global_key);
+    } else {
+        market_fixed.set_quote_global(expected_global_key);
+    }
+    Ok(())
+}
+
+/// Formal verification models `find_program_address`, so it keeps deriving.
+#[cfg(feature = "certora")]
+fn verify_market_global<'a, 'info>(
+    _market: &ManifestAccountInfo<'a, 'info, MarketFixed>,
+    _index: usize,
+    mint: &Pubkey,
+    global_key: &Pubkey,
+) -> ProgramResult {
+    let (expected_global_key, _global_bump) = get_global_address(mint);
+    require!(
+        expected_global_key == *global_key,
+        ManifestError::MissingGlobal,
+        "Unexpected global accounts",
+    )
+}
+
 /// Global create
 pub(crate) struct GlobalCreateContext<'a, 'info> {
     pub payer: Signer<'a, 'info>,
@@ -671,6 +735,8 @@ pub(crate) struct GlobalCreateContext<'a, 'info> {
     pub global_mint: MintAccountInfo<'a, 'info>,
     pub global_vault: EmptyAccount<'a, 'info>,
     pub token_program: TokenProgram<'a, 'info>,
+    /// Bump of the global PDA, derived once here for signing and the header.
+    pub global_bump: u8,
 }
 
 impl<'a, 'info> GlobalCreateContext<'a, 'info> {
@@ -684,7 +750,7 @@ impl<'a, 'info> GlobalCreateContext<'a, 'info> {
         let global_mint: MintAccountInfo = MintAccountInfo::new(next_account_info(account_iter)?)?;
         let global_vault: EmptyAccount = EmptyAccount::new(next_account_info(account_iter)?)?;
 
-        let (expected_global_key, _global_bump) = get_global_address(global_mint.info.key);
+        let (expected_global_key, global_bump) = get_global_address(global_mint.info.key);
         assert_eq!(expected_global_key, *global.info.key);
 
         let token_program: TokenProgram = TokenProgram::new(next_account_info(account_iter)?)?;
@@ -695,6 +761,7 @@ impl<'a, 'info> GlobalCreateContext<'a, 'info> {
             global_mint,
             global_vault,
             token_program,
+            global_bump,
         })
     }
 }
@@ -717,9 +784,14 @@ impl<'a, 'info> GlobalAddTraderContext<'a, 'info> {
         let global_data: Ref<&mut [u8]> = global.data.borrow();
         let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(&global_data, 0_u32);
         let global_mint_key: &Pubkey = global_fixed.get_mint();
-        let (expected_global_key, _global_bump) = get_global_address(global_mint_key);
+        // The global is validated against its own stored bump, see
+        // `is_global_address` for why that is as strong as deriving it.
         require!(
-            expected_global_key == *global.info.key,
+            is_global_address(
+                global.info.key,
+                global_mint_key,
+                global_fixed.get_global_bump()
+            ),
             ManifestError::MissingGlobal,
             "Unexpected global accounts",
         )?;
@@ -759,9 +831,14 @@ impl<'a, 'info> GlobalDepositContext<'a, 'info> {
         let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(&global_data, 0_u32);
 
         let global_mint_key: &Pubkey = global_fixed.get_mint();
-        let (expected_global_key, _global_bump) = get_global_address(global_mint_key);
+        // The global is validated against its own stored bump, see
+        // `is_global_address` for why that is as strong as deriving it.
         require!(
-            expected_global_key == *global.info.key,
+            is_global_address(
+                global.info.key,
+                global_mint_key,
+                global_fixed.get_global_bump()
+            ),
             ManifestError::MissingGlobal,
             "Unexpected global accounts",
         )?;
@@ -815,9 +892,14 @@ impl<'a, 'info> GlobalWithdrawContext<'a, 'info> {
         let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(&global_data, 0_u32);
 
         let global_mint_key: &Pubkey = global_fixed.get_mint();
-        let (expected_global_key, _global_bump) = get_global_address(global_mint_key);
+        // The global is validated against its own stored bump, see
+        // `is_global_address` for why that is as strong as deriving it.
         require!(
-            expected_global_key == *global.info.key,
+            is_global_address(
+                global.info.key,
+                global_mint_key,
+                global_fixed.get_global_bump()
+            ),
             ManifestError::MissingGlobal,
             "Unexpected global accounts",
         )?;
@@ -873,9 +955,14 @@ impl<'a, 'info> GlobalEvictContext<'a, 'info> {
         let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(&global_data, 0_u32);
 
         let global_mint_key: &Pubkey = global_fixed.get_mint();
-        let (expected_global_key, _global_bump) = get_global_address(global_mint_key);
+        // The global is validated against its own stored bump, see
+        // `is_global_address` for why that is as strong as deriving it.
         require!(
-            expected_global_key == *global.info.key,
+            is_global_address(
+                global.info.key,
+                global_mint_key,
+                global_fixed.get_global_bump()
+            ),
             ManifestError::MissingGlobal,
             "Unexpected global accounts",
         )?;
@@ -935,9 +1022,14 @@ impl<'a, 'info> GlobalCleanContext<'a, 'info> {
         let global_data: Ref<&mut [u8]> = global.data.borrow();
         let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(&global_data, 0_u32);
         let global_mint_key: &Pubkey = global_fixed.get_mint();
-        let (expected_global_key, _global_bump) = get_global_address(global_mint_key);
+        // The global is validated against its own stored bump, see
+        // `is_global_address` for why that is as strong as deriving it.
         require!(
-            expected_global_key == *global.info.key,
+            is_global_address(
+                global.info.key,
+                global_mint_key,
+                global_fixed.get_global_bump()
+            ),
             ManifestError::MissingGlobal,
             "Unexpected global accounts",
         )?;

--- a/programs/manifest/src/validation/loaders.rs
+++ b/programs/manifest/src/validation/loaders.rs
@@ -711,7 +711,20 @@ fn verify_market_global<'a, 'info>(
     Ok(())
 }
 
-/// Formal verification models `find_program_address`, so it keeps deriving.
+/// Formal verification derives the address every time instead of reading the
+/// cache, for two reasons. The cached fields do not exist in that build:
+/// `MarketFixed` is 256 bytes either way, and under `certora` the same 64
+/// bytes hold the informational atom totals the specs reason about. And the
+/// prover models `create_program_address`, so deriving is what lets it state
+/// the property directly, that the account is the canonical global for this
+/// mint.
+///
+/// That splits the coverage: the prover checks the property, and the tests
+/// check that the fast path implements it. `is_global_address` is compared
+/// against `create_program_address` for every bump in `manifest_checker`, and
+/// `tests/cases/global_address.rs` covers the cache being filled in on an old
+/// market, a global for the wrong mint, and a forged account that copies a
+/// real global but does not sit at the derived address.
 #[cfg(feature = "certora")]
 fn verify_market_global<'a, 'info>(
     _market: &ManifestAccountInfo<'a, 'info, MarketFixed>,

--- a/programs/manifest/src/validation/manifest_checker.rs
+++ b/programs/manifest/src/validation/manifest_checker.rs
@@ -137,3 +137,86 @@ macro_rules! global_seeds_with_bump {
 pub fn get_global_address(mint: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(global_seeds!(mint), &crate::ID)
 }
+
+/// Whether `key` is the global account address for `mint` derived with
+/// `bump`, i.e. whether
+/// `Pubkey::create_program_address(&[b"global", mint, &[bump]], &crate::ID)`
+/// would return it.
+///
+/// Program derived addresses are what make the global account checks
+/// meaningful: only this program can sign for such an address, so only its
+/// own init could have created an account there. Deriving with the syscall
+/// costs 1,500 CU (and `find_program_address` that much per bump tried), so
+/// this does the same computation, the seed hash followed by rejecting hashes
+/// that are on the ed25519 curve, with the sha256 and curve syscalls
+/// directly for about 350 CU. Exhaustively checked against
+/// `create_program_address` in the tests below.
+#[cfg(not(feature = "certora"))]
+pub fn is_global_address(key: &Pubkey, mint: &Pubkey, bump: u8) -> bool {
+    let hash: [u8; 32] = solana_program::hash::hashv(&[
+        b"global",
+        mint.as_ref(),
+        &[bump],
+        crate::ID.as_ref(),
+        PDA_MARKER,
+    ])
+    .to_bytes();
+    hash == key.to_bytes()
+        && !solana_curve25519::edwards::validate_edwards(
+            &solana_curve25519::edwards::PodEdwardsPoint(hash),
+        )
+}
+
+/// Formal verification models `create_program_address` but not the hash and
+/// curve syscalls, so it keeps the derivation.
+#[cfg(feature = "certora")]
+pub fn is_global_address(key: &Pubkey, mint: &Pubkey, bump: u8) -> bool {
+    Pubkey::create_program_address(&[b"global", mint.as_ref(), &[bump]], &crate::ID) == Ok(*key)
+}
+
+/// Domain separator the runtime appends when hashing program derived address
+/// seeds.
+#[cfg(not(feature = "certora"))]
+const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
+
+#[cfg(all(test, not(feature = "certora")))]
+mod is_global_address_test {
+    use super::*;
+
+    #[test]
+    fn matches_create_program_address_for_every_bump() {
+        for _ in 0..32 {
+            let mint: Pubkey = Pubkey::new_unique();
+            let (global, bump) = get_global_address(&mint);
+            assert!(is_global_address(&global, &mint, bump));
+            assert!(!is_global_address(&Pubkey::new_unique(), &mint, bump));
+            assert!(!is_global_address(&global, &Pubkey::new_unique(), bump));
+
+            for candidate_bump in 0..=u8::MAX {
+                let seeds: [&[u8]; 3] = [b"global", mint.as_ref(), &[candidate_bump]];
+                match Pubkey::create_program_address(&seeds, &crate::ID) {
+                    Ok(address) => {
+                        assert!(is_global_address(&address, &mint, candidate_bump));
+                        assert_eq!(candidate_bump == bump, address == global);
+                    }
+                    Err(_) => {
+                        // The seed hash is on the curve, so somebody could
+                        // hold its private key. It must be rejected even for
+                        // an account that sits exactly at that key.
+                        let on_curve: Pubkey = Pubkey::from(
+                            solana_program::hash::hashv(&[
+                                b"global",
+                                mint.as_ref(),
+                                &[candidate_bump],
+                                crate::ID.as_ref(),
+                                PDA_MARKER,
+                            ])
+                            .to_bytes(),
+                        );
+                        assert!(!is_global_address(&on_curve, &mint, candidate_bump));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/programs/manifest/src/validation/manifest_checker.rs
+++ b/programs/manifest/src/validation/manifest_checker.rs
@@ -175,10 +175,15 @@ pub fn is_global_address(key: &Pubkey, mint: &Pubkey, bump: u8) -> bool {
 }
 
 /// Domain separator the runtime appends when hashing program derived address
-/// seeds.
+/// seeds. Only the hand rolled derivation above needs it, and that is not the
+/// one the `certora` build uses.
 #[cfg(not(feature = "certora"))]
 const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
+/// Exhaustive check that the hand rolled derivation agrees with
+/// `create_program_address`. It covers the non certora `is_global_address`,
+/// which is the one the prover never sees, so this is where that path is
+/// pinned down.
 #[cfg(all(test, not(feature = "certora")))]
 mod is_global_address_test {
     use super::*;

--- a/programs/manifest/tests/cases/cu.rs
+++ b/programs/manifest/tests/cases/cu.rs
@@ -17,6 +17,7 @@
 
 use std::{cell::RefMut, rc::Rc};
 
+use hypertree::get_helper;
 use manifest::{
     program::{
         batch_update::{CancelOrderParams, PlaceOrderParams},
@@ -25,9 +26,10 @@ use manifest::{
         global_add_trader_instruction, global_deposit_instruction, global_withdraw_instruction,
         swap_instruction, withdraw_instruction,
     },
-    state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, OrderType},
+    state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, MarketFixed, OrderType},
     validation::{get_global_address, get_global_vault_address, get_vault_address},
 };
+use solana_account::{Account, AccountSharedData};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program::{program_pack::Pack, pubkey::Pubkey, rent::Rent, system_instruction};
@@ -585,5 +587,74 @@ async fn cu_global_test() -> anyhow::Result<()> {
         &[&payer_keypair],
     )
     .await?;
+    Ok(())
+}
+
+/// Batch update carrying the global accounts for both sides. The first call
+/// is on a market whose cached global addresses were cleared, so it derives
+/// and stores them (its cost depends on how many bumps the search tries for
+/// the fixture's random mints); the second call takes the cached path.
+#[tokio::test]
+async fn cu_batch_update_with_globals_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.global_add_trader().await?;
+    test_fixture.global_deposit(10 * USDC_UNIT_SIZE).await?;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let market: Pubkey = test_fixture.market_fixture.key;
+
+    // Clear the cache to behave like a market from before it existed.
+    let mut market_account: Account = test_fixture
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_account(market)
+        .await?
+        .expect("market exists");
+    market_account.data[192..256].fill(0);
+    test_fixture
+        .context
+        .borrow_mut()
+        .set_account(&market, &AccountSharedData::from(market_account));
+
+    for (name, price_mantissa) in [("uncached", 1u32), ("cached", 2u32)] {
+        let place_global_bid_ix: Instruction = batch_update_instruction(
+            &market,
+            &payer,
+            None,
+            vec![],
+            vec![PlaceOrderParams::new(
+                10,
+                price_mantissa,
+                0,
+                true,
+                OrderType::Global,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            Some(test_fixture.sol_mint_fixture.key),
+            None,
+            Some(test_fixture.usdc_mint_fixture.key),
+            None,
+        );
+        measure_and_send(
+            &test_fixture,
+            &format!("batch_update_global_place_1[{name}]"),
+            &[place_global_bid_ix],
+            &payer,
+            &[&payer_keypair],
+        )
+        .await?;
+    }
+    let market_account: Account = test_fixture
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_account(market)
+        .await?
+        .expect("market exists");
+    let market_fixed: &MarketFixed = get_helper::<MarketFixed>(&market_account.data, 0_u32);
+    assert_ne!(*market_fixed.get_base_global(), Pubkey::default());
+    assert_ne!(*market_fixed.get_quote_global(), Pubkey::default());
     Ok(())
 }

--- a/programs/manifest/tests/cases/cu.rs
+++ b/programs/manifest/tests/cases/cu.rs
@@ -92,6 +92,25 @@ async fn measure_and_send(
     Ok(units_consumed)
 }
 
+/// Simulates `instructions`, requiring success, and prints the compute units
+/// as `CU <name>: <units>` without executing anything. For comparing two
+/// variants of the same instruction from one state: simulation does not
+/// commit, so each sample starts from exactly the state the caller set up.
+async fn measure(
+    test_fixture: &TestFixture,
+    name: &str,
+    instructions: &[Instruction],
+    payer: &Pubkey,
+    signers: &[&Keypair],
+) -> u64 {
+    let (result, units_consumed) = simulate(test_fixture, instructions, payer, signers).await;
+    if let Err(error) = result {
+        panic!("{name} simulation failed: {error}");
+    }
+    println!("CU {name}: {units_consumed}");
+    units_consumed
+}
+
 /// A market keypair whose base and quote vault PDAs derive on the first bump.
 fn market_keypair_with_first_bump_vaults(base_mint: &Pubkey, quote_mint: &Pubkey) -> Keypair {
     loop {
@@ -674,8 +693,42 @@ async fn cu_batch_update_with_globals_test() -> anyhow::Result<()> {
     )
     .await?;
 
-    // Creating the market cached both addresses, so clear them to behave like
-    // a market from before the cache existed.
+    // Both samples are simulations of the same instruction, and simulating
+    // does not commit, so both run against this same state: an empty book, an
+    // untouched global, and a seat that has not traded. The only difference
+    // between them is the 64 bytes of cached addresses, which is the point of
+    // the comparison; sending either one first would leave the second facing a
+    // resting order and a changed global balance.
+    let place_global_bid_ix: Instruction = batch_update_instruction(
+        &market,
+        &payer,
+        None,
+        vec![],
+        vec![PlaceOrderParams::new(
+            10,
+            1,
+            0,
+            true,
+            OrderType::Global,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+        )],
+        Some(base_mint),
+        None,
+        Some(quote_mint),
+        None,
+    );
+
+    // Creating the market cached both addresses, so this is the cached path.
+    let cached_units: u64 = measure(
+        &test_fixture,
+        "batch_update_global_place_1[cached]",
+        &[place_global_bid_ix.clone()],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await;
+
+    // Clear just the cache, to behave like a market from before it existed.
     let mut market_account: Account = test_fixture
         .context
         .borrow_mut()
@@ -689,34 +742,32 @@ async fn cu_batch_update_with_globals_test() -> anyhow::Result<()> {
         .borrow_mut()
         .set_account(&market, &AccountSharedData::from(market_account));
 
-    for (name, price_mantissa) in [("uncached", 1u32), ("cached", 2u32)] {
-        let place_global_bid_ix: Instruction = batch_update_instruction(
-            &market,
-            &payer,
-            None,
-            vec![],
-            vec![PlaceOrderParams::new(
-                10,
-                price_mantissa,
-                0,
-                true,
-                OrderType::Global,
-                NO_EXPIRATION_LAST_VALID_SLOT,
-            )],
-            Some(base_mint),
-            None,
-            Some(quote_mint),
-            None,
+    let uncached_units: u64 = measure(
+        &test_fixture,
+        "batch_update_global_place_1[uncached]",
+        &[place_global_bid_ix.clone()],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await;
+    // Only the BPF program meters compute, see the module docs, so this only
+    // says anything under `cargo test-sbf`.
+    if cfg!(feature = "test-sbf") {
+        assert!(
+            uncached_units > cached_units,
+            "deriving both globals must cost more than comparing them",
         );
-        measure_and_send(
-            &test_fixture,
-            &format!("batch_update_global_place_1[{name}]"),
-            &[place_global_bid_ix],
-            &payer,
-            &[&payer_keypair],
-        )
-        .await?;
     }
+
+    // Run it for real from the cleared state, so the cache being filled in is
+    // covered too.
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[place_global_bid_ix],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
     let market_account: Account = test_fixture
         .context
         .borrow_mut()

--- a/programs/manifest/tests/cases/cu.rs
+++ b/programs/manifest/tests/cases/cu.rs
@@ -116,6 +116,48 @@ fn mint_keypair_with_first_bump_globals() -> Keypair {
     }
 }
 
+/// Creates and initializes a mint whose global PDAs derive on the first bump,
+/// with the payer as its mint authority. Measurements that touch a global
+/// account use these so the derivation is a single attempt.
+async fn create_first_bump_globals_mint(
+    test_fixture: &TestFixture,
+    decimals: u8,
+) -> anyhow::Result<Pubkey> {
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let mint_keypair: Keypair = mint_keypair_with_first_bump_globals();
+    let mint: Pubkey = mint_keypair.pubkey();
+    let rent: Rent = test_fixture
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_rent()
+        .await?;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            system_instruction::create_account(
+                &payer,
+                &mint,
+                rent.minimum_balance(spl_token::state::Mint::LEN),
+                spl_token::state::Mint::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_mint(
+                &spl_token::id(),
+                &mint,
+                &payer,
+                None,
+                decimals,
+            )?,
+        ],
+        Some(&payer),
+        &[&payer_keypair, &mint_keypair],
+    )
+    .await?;
+    Ok(mint)
+}
+
 /// Creates a market on the fixture's SOL/USDC mints whose vault PDAs derive on
 /// the first bump, returning its key.
 async fn create_market_with_first_bump_vaults(
@@ -186,17 +228,16 @@ async fn cu_create_market_test() -> anyhow::Result<()> {
     let test_fixture: TestFixture = TestFixture::new().await;
     let payer: Pubkey = test_fixture.payer();
     let payer_keypair: Keypair = test_fixture.payer_keypair();
-    let market_keypair: Keypair = market_keypair_with_first_bump_vaults(
-        &test_fixture.sol_mint_fixture.key,
-        &test_fixture.usdc_mint_fixture.key,
-    );
+    // Creating a market derives both vault PDAs and caches both global
+    // addresses, so the mints and the market key are all chosen to derive on
+    // the first bump; otherwise this number moves by about 1,500 CU per extra
+    // attempt from run to run.
+    let base_mint: Pubkey = create_first_bump_globals_mint(&test_fixture, 9).await?;
+    let quote_mint: Pubkey = create_first_bump_globals_mint(&test_fixture, 6).await?;
+    let market_keypair: Keypair = market_keypair_with_first_bump_vaults(&base_mint, &quote_mint);
 
-    let create_market_ixs: Vec<Instruction> = create_market_instructions(
-        &market_keypair.pubkey(),
-        &test_fixture.sol_mint_fixture.key,
-        &test_fixture.usdc_mint_fixture.key,
-        &payer,
-    )?;
+    let create_market_ixs: Vec<Instruction> =
+        create_market_instructions(&market_keypair.pubkey(), &base_mint, &quote_mint, &payer)?;
     // Includes the system program create account instruction.
     measure_and_send(
         &test_fixture,
@@ -506,30 +547,7 @@ async fn cu_global_test() -> anyhow::Result<()> {
 
     // A mint whose global PDAs derive on the first bump, with the payer as its
     // mint authority, and a token account for the payer.
-    let mint_keypair: Keypair = mint_keypair_with_first_bump_globals();
-    let mint: Pubkey = mint_keypair.pubkey();
-    let rent: Rent = test_fixture
-        .context
-        .borrow_mut()
-        .banks_client
-        .get_rent()
-        .await?;
-    send_tx_with_retry(
-        Rc::clone(&test_fixture.context),
-        &[
-            system_instruction::create_account(
-                &payer,
-                &mint,
-                rent.minimum_balance(spl_token::state::Mint::LEN),
-                spl_token::state::Mint::LEN as u64,
-                &spl_token::id(),
-            ),
-            spl_token::instruction::initialize_mint(&spl_token::id(), &mint, &payer, None, 6)?,
-        ],
-        Some(&payer),
-        &[&payer_keypair, &mint_keypair],
-    )
-    .await?;
+    let mint: Pubkey = create_first_bump_globals_mint(&test_fixture, 6).await?;
     let token_account: TokenAccountFixture =
         TokenAccountFixture::new(Rc::clone(&test_fixture.context), &mint, &payer).await;
     send_tx_with_retry(
@@ -592,19 +610,72 @@ async fn cu_global_test() -> anyhow::Result<()> {
 
 /// Batch update carrying the global accounts for both sides. The first call
 /// is on a market whose cached global addresses were cleared, so it derives
-/// and stores them (its cost depends on how many bumps the search tries for
-/// the fixture's random mints); the second call takes the cached path.
+/// and stores them; the second takes the cached path. Both mints and the
+/// market key derive on the first bump so the uncached number is a single
+/// derivation attempt per side rather than however many the fixture's random
+/// mints happen to need.
 #[tokio::test]
 async fn cu_batch_update_with_globals_test() -> anyhow::Result<()> {
-    let mut test_fixture: TestFixture = TestFixture::new().await;
-    test_fixture.claim_seat().await?;
-    test_fixture.global_add_trader().await?;
-    test_fixture.global_deposit(10 * USDC_UNIT_SIZE).await?;
+    let test_fixture: TestFixture = TestFixture::new().await;
     let payer: Pubkey = test_fixture.payer();
     let payer_keypair: Keypair = test_fixture.payer_keypair();
-    let market: Pubkey = test_fixture.market_fixture.key;
+    let amount_atoms: u64 = 10 * USDC_UNIT_SIZE;
 
-    // Clear the cache to behave like a market from before it existed.
+    let base_mint: Pubkey = create_first_bump_globals_mint(&test_fixture, 9).await?;
+    let quote_mint: Pubkey = create_first_bump_globals_mint(&test_fixture, 6).await?;
+    let market_keypair: Keypair = market_keypair_with_first_bump_vaults(&base_mint, &quote_mint);
+    let market: Pubkey = market_keypair.pubkey();
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &create_market_instructions(&market, &base_mint, &quote_mint, &payer)?[..],
+        Some(&payer),
+        &[&payer_keypair, &market_keypair],
+    )
+    .await?;
+
+    // A seat on the market, both globals, and quote tokens on the global to
+    // back the global bid placed below.
+    let quote_token_account: TokenAccountFixture =
+        TokenAccountFixture::new(Rc::clone(&test_fixture.context), &quote_mint, &payer).await;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            claim_seat_instruction(&market, &payer),
+            create_global_instruction(&base_mint, &payer, &spl_token::id()),
+            create_global_instruction(&quote_mint, &payer, &spl_token::id()),
+            spl_token::instruction::mint_to(
+                &spl_token::id(),
+                &quote_mint,
+                &quote_token_account.key,
+                &payer,
+                &[&payer],
+                amount_atoms,
+            )?,
+        ],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    let (quote_global, _) = get_global_address(&quote_mint);
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            global_add_trader_instruction(&quote_global, &payer),
+            global_deposit_instruction(
+                &quote_mint,
+                &payer,
+                &quote_token_account.key,
+                &spl_token::id(),
+                amount_atoms,
+            ),
+        ],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    // Creating the market cached both addresses, so clear them to behave like
+    // a market from before the cache existed.
     let mut market_account: Account = test_fixture
         .context
         .borrow_mut()
@@ -632,9 +703,9 @@ async fn cu_batch_update_with_globals_test() -> anyhow::Result<()> {
                 OrderType::Global,
                 NO_EXPIRATION_LAST_VALID_SLOT,
             )],
-            Some(test_fixture.sol_mint_fixture.key),
+            Some(base_mint),
             None,
-            Some(test_fixture.usdc_mint_fixture.key),
+            Some(quote_mint),
             None,
         );
         measure_and_send(

--- a/programs/manifest/tests/cases/global_address.rs
+++ b/programs/manifest/tests/cases/global_address.rs
@@ -1,0 +1,323 @@
+//! Validation of global accounts: the canonical global addresses cached on
+//! the market, how markets from before the cache existed pick it up, and that
+//! accounts which are not the canonical global PDA are rejected on every path
+//! even when they carry a perfect copy of a real global's data.
+
+use std::rc::Rc;
+
+use borsh::BorshSerialize;
+use hypertree::get_helper;
+use manifest::{
+    program::{
+        batch_update::PlaceOrderParams, batch_update_instruction, global_add_trader_instruction,
+        global_deposit_instruction, ManifestInstruction,
+    },
+    state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, MarketFixed, OrderType, RestingOrder},
+    validation::{get_global_address, get_global_vault_address, get_vault_address},
+};
+use solana_account::{Account, AccountSharedData};
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_program::{pubkey::Pubkey, system_program};
+use solana_program_test::tokio;
+
+use crate::{send_tx_with_retry, TestFixture};
+
+/// Byte offsets of the cached global addresses in `MarketFixed`: the last 64
+/// bytes of the 256 byte header.
+const BASE_GLOBAL_OFFSET: usize = 192;
+const QUOTE_GLOBAL_OFFSET: usize = 224;
+
+async fn get_account(test_fixture: &TestFixture, key: &Pubkey) -> Account {
+    test_fixture
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_account(*key)
+        .await
+        .unwrap()
+        .expect("account exists")
+}
+
+async fn cached_globals(test_fixture: &TestFixture) -> (Pubkey, Pubkey) {
+    let market: Account = get_account(test_fixture, &test_fixture.market_fixture.key).await;
+    let market_fixed: &MarketFixed = get_helper::<MarketFixed>(&market.data, 0_u32);
+    (
+        *market_fixed.get_base_global(),
+        *market_fixed.get_quote_global(),
+    )
+}
+
+/// Turns the fixture's market into one created before the cache existed by
+/// zeroing the cached addresses in place.
+async fn clear_cached_globals(test_fixture: &TestFixture) {
+    let mut market: Account = get_account(test_fixture, &test_fixture.market_fixture.key).await;
+    market.data[BASE_GLOBAL_OFFSET..QUOTE_GLOBAL_OFFSET + 32].fill(0);
+    test_fixture.context.borrow_mut().set_account(
+        &test_fixture.market_fixture.key,
+        &AccountSharedData::from(market),
+    );
+    assert_eq!(
+        cached_globals(test_fixture).await,
+        (Pubkey::default(), Pubkey::default())
+    );
+}
+
+/// Batch update placing one global bid with the global accounts for
+/// `global_mint` given explicitly, so tests can substitute the global account.
+fn global_bid_instruction(
+    test_fixture: &TestFixture,
+    global_mint: &Pubkey,
+    global: &Pubkey,
+) -> Instruction {
+    let market: Pubkey = test_fixture.market_fixture.key;
+    let payer: Pubkey = test_fixture.payer();
+    let mut instruction: Instruction = batch_update_instruction(
+        &market,
+        &payer,
+        None,
+        vec![],
+        vec![PlaceOrderParams::new(
+            10,
+            1,
+            0,
+            true,
+            OrderType::Global,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+        )],
+        None,
+        None,
+        Some(*global_mint),
+        None,
+    );
+    // Accounts: payer, market, system program, mint, global, global vault,
+    // market vault, token program.
+    assert_eq!(
+        instruction.accounts[4].pubkey,
+        get_global_address(global_mint).0
+    );
+    instruction.accounts[4] = AccountMeta::new(*global, false);
+    instruction
+}
+
+async fn send(test_fixture: &TestFixture, instruction: Instruction) -> bool {
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[instruction],
+        Some(&test_fixture.payer()),
+        &[&payer_keypair],
+    )
+    .await
+    .is_ok()
+}
+
+#[tokio::test]
+async fn global_addresses_cached_on_create_test() -> anyhow::Result<()> {
+    let test_fixture: TestFixture = TestFixture::new().await;
+    let (base_global, quote_global) = cached_globals(&test_fixture).await;
+    assert_eq!(
+        base_global,
+        get_global_address(&test_fixture.sol_mint_fixture.key).0
+    );
+    assert_eq!(
+        quote_global,
+        get_global_address(&test_fixture.usdc_mint_fixture.key).0
+    );
+    Ok(())
+}
+
+/// A market created before the cache existed gets both addresses filled in by
+/// its first global batch update, and keeps trading afterwards.
+#[tokio::test]
+async fn global_addresses_lazily_cached_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.global_add_trader().await?;
+    test_fixture.global_deposit(1_000_000).await?;
+    clear_cached_globals(&test_fixture).await;
+
+    // Both mints are passed, so both sides get cached.
+    test_fixture
+        .batch_update_with_global_for_keypair(
+            None,
+            vec![],
+            vec![PlaceOrderParams::new(
+                10,
+                1,
+                0,
+                true,
+                OrderType::Global,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            &test_fixture.payer_keypair().insecure_clone(),
+        )
+        .await?;
+    assert_eq!(
+        cached_globals(&test_fixture).await,
+        (
+            get_global_address(&test_fixture.sol_mint_fixture.key).0,
+            get_global_address(&test_fixture.usdc_mint_fixture.key).0,
+        )
+    );
+
+    // Second trade takes the cached path.
+    test_fixture
+        .batch_update_with_global_for_keypair(
+            None,
+            vec![],
+            vec![PlaceOrderParams::new(
+                10,
+                2,
+                0,
+                true,
+                OrderType::Global,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            &test_fixture.payer_keypair().insecure_clone(),
+        )
+        .await?;
+    test_fixture.market_fixture.reload().await;
+    let orders: Vec<RestingOrder> = test_fixture.market_fixture.get_resting_orders().await;
+    assert_eq!(orders.len(), 2);
+    Ok(())
+}
+
+/// The global for one mint is not accepted in the slot of another, cached or
+/// not.
+#[tokio::test]
+async fn global_address_other_mint_rejected_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.global_add_trader().await?;
+    test_fixture.global_deposit(1_000_000).await?;
+    let usdc_mint: Pubkey = test_fixture.usdc_mint_fixture.key;
+    let sol_global: Pubkey = get_global_address(&test_fixture.sol_mint_fixture.key).0;
+
+    // Cached path.
+    assert!(
+        !send(
+            &test_fixture,
+            global_bid_instruction(&test_fixture, &usdc_mint, &sol_global)
+        )
+        .await
+    );
+    // Derivation path of a market from before the cache.
+    clear_cached_globals(&test_fixture).await;
+    assert!(
+        !send(
+            &test_fixture,
+            global_bid_instruction(&test_fixture, &usdc_mint, &sol_global)
+        )
+        .await
+    );
+    assert_eq!(
+        cached_globals(&test_fixture).await,
+        (Pubkey::default(), Pubkey::default())
+    );
+    // The real global still works.
+    let usdc_global: Pubkey = get_global_address(&usdc_mint).0;
+    assert!(
+        send(
+            &test_fixture,
+            global_bid_instruction(&test_fixture, &usdc_mint, &usdc_global)
+        )
+        .await
+    );
+    Ok(())
+}
+
+/// The attack the address check exists for: an account owned by this program
+/// that is a byte for byte copy of a real global, including its stored bump,
+/// but does not sit at the program derived address. The runtime does not let
+/// anyone assign a non-empty account to a program, so this can only be set up
+/// in a test, and every path must still reject it.
+#[tokio::test]
+async fn global_forged_account_rejected_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.global_add_trader().await?;
+    test_fixture.global_deposit(1_000_000).await?;
+    let usdc_mint: Pubkey = test_fixture.usdc_mint_fixture.key;
+    let usdc_global: Pubkey = get_global_address(&usdc_mint).0;
+    let forged_global: Pubkey = Pubkey::new_unique();
+    let real: Account = get_account(&test_fixture, &usdc_global).await;
+    assert_eq!(real.owner, manifest::id());
+    test_fixture
+        .context
+        .borrow_mut()
+        .set_account(&forged_global, &AccountSharedData::from(real));
+
+    // Batch update, cached and derivation paths.
+    assert!(
+        !send(
+            &test_fixture,
+            global_bid_instruction(&test_fixture, &usdc_mint, &forged_global)
+        )
+        .await
+    );
+    clear_cached_globals(&test_fixture).await;
+    assert!(
+        !send(
+            &test_fixture,
+            global_bid_instruction(&test_fixture, &usdc_mint, &forged_global)
+        )
+        .await
+    );
+
+    // Global instructions validate against the stored bump.
+    let payer: Pubkey = test_fixture.payer();
+    let add_trader: Instruction = global_add_trader_instruction(&forged_global, &payer);
+    assert!(!send(&test_fixture, add_trader).await);
+
+    let mut deposit: Instruction = global_deposit_instruction(
+        &usdc_mint,
+        &payer,
+        &test_fixture.payer_usdc_fixture.key,
+        &spl_token::id(),
+        1,
+    );
+    assert_eq!(deposit.accounts[1].pubkey, usdc_global);
+    deposit.accounts[1] = AccountMeta::new(forged_global, false);
+    assert!(!send(&test_fixture, deposit).await);
+
+    // And a swap that names the forged global.
+    let (sol_vault, _) = get_vault_address(
+        &test_fixture.market_fixture.key,
+        &test_fixture.sol_mint_fixture.key,
+    );
+    let (usdc_vault, _) = get_vault_address(&test_fixture.market_fixture.key, &usdc_mint);
+    let swap: Instruction = Instruction {
+        program_id: manifest::id(),
+        accounts: vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new(test_fixture.market_fixture.key, false),
+            AccountMeta::new_readonly(system_program::id(), false),
+            AccountMeta::new(test_fixture.payer_sol_fixture.key, false),
+            AccountMeta::new(test_fixture.payer_usdc_fixture.key, false),
+            AccountMeta::new(sol_vault, false),
+            AccountMeta::new(usdc_vault, false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+            AccountMeta::new(forged_global, false),
+            AccountMeta::new(get_global_vault_address(&usdc_mint).0, false),
+        ],
+        data: [
+            ManifestInstruction::Swap.to_vec(),
+            manifest::program::SwapParams::new(1, 0, false, true)
+                .try_to_vec()
+                .unwrap(),
+        ]
+        .concat(),
+    };
+    assert!(!send(&test_fixture, swap).await);
+
+    // The genuine global is unaffected.
+    assert!(
+        send(
+            &test_fixture,
+            global_bid_instruction(&test_fixture, &usdc_mint, &usdc_global)
+        )
+        .await
+    );
+    Ok(())
+}

--- a/programs/manifest/tests/cases/mod.rs
+++ b/programs/manifest/tests/cases/mod.rs
@@ -7,6 +7,7 @@ pub mod deposit;
 pub mod exploit_global_clean;
 pub mod exploit_global_reduce;
 pub mod global;
+pub mod global_address;
 pub mod loaders;
 pub mod matching;
 pub mod place_order;


### PR DESCRIPTION
Every batch update or swap that carries global accounts validated them with find_program_address, which costs about 1,500 CU per bump tried and runs twice when both sides are global. The addresses never change once a market exists, so store them in MarketFixed (in what was padding3) and validate by comparing against the stored key.

A market created before this field existed has zeroes there, so the first global instruction on it derives the addresses and stores them; after that it takes the cached path. Markets created from now on get both addresses at creation.

The check that replaces the search still has to prove the account is at the program derived address, so is_global_address rebuilds the address from the seeds, the stored bump, the program id and the PDA marker with one sha256 and rejects it if the result is on the curve. That is the same computation find_program_address does per attempt, without the search, and it keeps the property the old code documented: an account owned by this program that is a byte for byte copy of a real global, including its bump, is still rejected because it does not sit at the derived address.

tests/cases/global_address.rs covers caching at creation, lazy caching on an old market, a global for the wrong mint, and the forged account attack the check exists for. The exhaustive bump test lives next to is_global_address.