### PR TITLE
Stop logging the orders a batch update places and cancels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,7 @@ version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrayref",
+ "base64 0.21.7",
  "borsh 0.10.4",
  "bytemuck",
  "calltrace",

--- a/client/idl/generateClient.js
+++ b/client/idl/generateClient.js
@@ -48,6 +48,38 @@ async function main() {
           fs.writeFileSync(accountFile, source.replace(deserialize, checked));
         }
       }
+      if (programName === 'manifest') {
+        // These two events are no longer emitted, see logs.rs. Solita does not
+        // carry documentation from the IDL, so the note that says so is put
+        // back here every time the client is regenerated.
+        const historicalBanner =
+          '/**\n' +
+          ' * Historical. The program stopped emitting this event when batch update\n' +
+          ' * stopped logging the orders it places and cancels; it is kept so that\n' +
+          ' * transactions from before that can still be decoded. Nothing emits it on new\n' +
+          ' * transactions.\n' +
+          ' *\n' +
+          ' * To learn which orders rested, read the `Program return:` line of the batch\n' +
+          ' * update instruction rather than watching for this event. Fills are still\n' +
+          ' * emitted as `FillLog`, and swap still emits `PlaceOrderLogV2`, which is a\n' +
+          ' * different event.\n' +
+          ' *\n' +
+          ' * @deprecated No longer emitted by the program.\n' +
+          ' */\n';
+        for (const accountName of ['PlaceOrderLog', 'CancelOrderLog']) {
+          const accountFile = path.join(sdkDir, 'accounts', `${accountName}.ts`);
+          const source = fs.readFileSync(accountFile, 'utf8');
+          const firstImport = source.indexOf('import ');
+          if (firstImport < 0) {
+            throw new Error(`Unable to annotate ${accountFile}`);
+          }
+          fs.writeFileSync(
+            accountFile,
+            source.slice(0, firstImport) + historicalBanner + source.slice(firstImport),
+          );
+        }
+      }
+
       console.log('Running prettier on generated files...');
       spawnSync('prettier', ['--write', sdkDir, '--trailing-comma all'], {
         stdio: 'inherit',

--- a/client/rust/slim/src/events.rs
+++ b/client/rust/slim/src/events.rs
@@ -114,7 +114,10 @@ pub struct FillLog {
     pub _padding: [u8; 14],
 }
 
-/// Emitted when an order is placed on the book.
+/// Historical. The program stopped emitting this when batch update stopped
+/// logging the orders it places; it is kept to decode transactions from
+/// before that. Placements on new transactions are not logged at all, and
+/// `PlaceOrderLogV2` below is a different event, still emitted by swap.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct PlaceOrderLog {
@@ -147,7 +150,9 @@ pub struct PlaceOrderLogV2 {
     pub _padding: [u8; 6],
 }
 
-/// Emitted when an order is cancelled.
+/// Historical, see [`PlaceOrderLog`]. The program no longer emits this; it is
+/// kept to decode transactions from before batch update stopped logging
+/// cancellations.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct CancelOrderLog {

--- a/client/ts/src/manifest/accounts/CancelOrderLog.ts
+++ b/client/ts/src/manifest/accounts/CancelOrderLog.ts
@@ -5,6 +5,19 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
+/**
+ * Historical. The program stopped emitting this event when batch update
+ * stopped logging the orders it places and cancels; it is kept so that
+ * transactions from before that can still be decoded. Nothing emits it on new
+ * transactions.
+ *
+ * To learn which orders rested, read the `Program return:` line of the batch
+ * update instruction rather than watching for this event. Fills are still
+ * emitted as `FillLog`, and swap still emits `PlaceOrderLogV2`, which is a
+ * different event.
+ *
+ * @deprecated No longer emitted by the program.
+ */
 import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
 import * as beetSolana from '@metaplex-foundation/beet-solana';

--- a/client/ts/src/manifest/accounts/PlaceOrderLog.ts
+++ b/client/ts/src/manifest/accounts/PlaceOrderLog.ts
@@ -5,6 +5,19 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
+/**
+ * Historical. The program stopped emitting this event when batch update
+ * stopped logging the orders it places and cancels; it is kept so that
+ * transactions from before that can still be decoded. Nothing emits it on new
+ * transactions.
+ *
+ * To learn which orders rested, read the `Program return:` line of the batch
+ * update instruction rather than watching for this event. Fills are still
+ * emitted as `FillLog`, and swap still emits `PlaceOrderLogV2`, which is a
+ * different event.
+ *
+ * @deprecated No longer emitted by the program.
+ */
 import * as web3 from '@solana/web3.js';
 import * as beet from '@metaplex-foundation/beet';
 import * as beetSolana from '@metaplex-foundation/beet-solana';

--- a/programs/manifest/Cargo.toml
+++ b/programs/manifest/Cargo.toml
@@ -64,6 +64,7 @@ solana-transaction = { workspace = true }
 solana-clock = { workspace = true }
 solana-instruction = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
+base64 = "0.21"
 tokio = { workspace = true }
 serde_json = "1.0.86"
 spl-associated-token-account = { version = "7", features = ["no-entrypoint"] }

--- a/programs/manifest/src/logs.rs
+++ b/programs/manifest/src/logs.rs
@@ -19,12 +19,23 @@ use crate::{
 #[cfg(not(feature = "certora"))]
 #[inline(never)] // ensure fresh stack frame
 pub fn emit_stack<T: bytemuck::Pod + Discriminant>(e: T) -> Result<(), ProgramError> {
-    // stack buffer, stack frames are 4kb
-    let mut buffer: [u8; 3000] = [0u8; 3000];
-    buffer[..8].copy_from_slice(&T::discriminant());
-    *bytemuck::from_bytes_mut::<T>(&mut buffer[8..8 + std::mem::size_of::<T>()]) = e;
-
-    solana_program::log::sol_log_data(&[&buffer[..(std::mem::size_of::<T>() + 8)]]);
+    // Stack buffer, stack frames are 4kb. Only the bytes written below are
+    // ever read, so it is not zeroed first; that was a 3000 byte memset on
+    // every event, 23 CU each.
+    let len: usize = 8 + std::mem::size_of::<T>();
+    assert!(len <= 3000);
+    let mut buffer: std::mem::MaybeUninit<[u8; 3000]> = std::mem::MaybeUninit::uninit();
+    // SAFETY: the discriminant and the value cover the first `len` bytes
+    // before that prefix is read, and `len` is checked against the buffer
+    // size above.
+    let bytes: &[u8] = unsafe {
+        let ptr: *mut u8 = buffer.as_mut_ptr() as *mut u8;
+        ptr.copy_from_nonoverlapping(T::discriminant().as_ptr(), 8);
+        ptr.add(8)
+            .copy_from_nonoverlapping(bytemuck::bytes_of(&e).as_ptr(), std::mem::size_of::<T>());
+        std::slice::from_raw_parts(ptr, len)
+    };
+    solana_program::log::sol_log_data(&[bytes]);
     Ok(())
 }
 
@@ -86,6 +97,21 @@ pub struct FillLog {
     pub _padding: [u8; 14],
 }
 
+/// No longer emitted. A batch update used to log one of these per order it
+/// placed, which cost the trader a `sol_log_data` syscall to be told what it
+/// had just asked for. Dropping this and [`CancelOrderLog`] is worth 450 CU
+/// on a batch update that places one order, 2,218 on one that places five and
+/// 373 on one that cancels one, measured on SBPF v2, so roughly 440 CU per
+/// order. It also stopped them crowding fills out of the capped transaction
+/// log, see `tests/cases/logs.rs`.
+///
+/// What reports the orders that rested is the batch update's return data,
+/// which the runtime also writes to the transaction log as a `Program return:`
+/// line. Read that rather than `meta.returnData`, which holds only whatever
+/// invocation ran last. See the note on `process_batch_update_core`.
+///
+/// The type is kept so that clients decoding historical transactions, and the
+/// generated clients and IDL, keep working. Nothing emits it.
 #[repr(C)]
 #[derive(Clone, Copy, Zeroable, Pod, ShankAccount)]
 pub struct PlaceOrderLog {
@@ -117,6 +143,8 @@ pub struct PlaceOrderLogV2 {
     pub _padding: [u8; 6],
 }
 
+/// No longer emitted, see [`PlaceOrderLog`]. Kept for clients decoding
+/// historical transactions.
 #[repr(C)]
 #[derive(Clone, Copy, Zeroable, Pod, ShankAccount)]
 pub struct CancelOrderLog {

--- a/programs/manifest/src/program/processor/batch_update.rs
+++ b/programs/manifest/src/program/processor/batch_update.rs
@@ -1,7 +1,6 @@
 use std::cell::RefMut;
 
 use crate::{
-    logs::{emit_stack, CancelOrderLog, PlaceOrderLog},
     program::get_trader_index_with_hint,
     quantities::{BaseAtoms, PriceConversionError, QuoteAtomsPerBaseAtom, WrapperU64},
     require,
@@ -14,7 +13,7 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use hypertree::{get_helper, trace, DataIndex, PodBool, RBNode};
+use hypertree::{get_helper, trace, DataIndex, RBNode};
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
     pubkey::Pubkey,
@@ -210,6 +209,38 @@ fn batch_place_order(
 }
 
 #[cfg_attr(all(feature = "certora", not(feature = "certora-test")), early_panic)]
+/// Note on logging: a batch update emits no event for the orders it places or
+/// cancels. Matching still logs what it needs to, a `FillLog` per fill and a
+/// `GlobalCleanupLog` when a global maker cannot cover its order; this is a
+/// statement about placement and cancellation events only.
+///
+/// Each event is a `sol_log_data` syscall the trader pays for, and it told the
+/// sender what it had just asked for. Measured on SBPF v2 against the build
+/// that still emitted them, dropping them is worth 450 CU on a batch update
+/// that places one order, 2,218 on one that places five, and 373 on one that
+/// cancels one, so roughly 440 CU per order.
+///
+/// What reports the orders that rested instead. They are in this instruction's
+/// return data, which the wrapper reads straight after the call, and the
+/// runtime also writes that return data into the transaction log as a
+/// `Program return:` line when this instruction exits. The structured
+/// `meta.returnData` is not the place to look for it, because the runtime
+/// clears that slot at the start of every invocation and a wrapper batch
+/// update ends with a fee transfer, but the log line is already written by
+/// then and stays. So an off chain consumer reads the `Program return:` line,
+/// subject to the same log truncation as everything else in the log, and
+/// `tests/cases/logs.rs` pins that. Fills, which a sender cannot predict, are
+/// still logged as events.
+///
+/// They also crowded out the fills. The transaction log is a fixed byte
+/// budget for the whole transaction and the runtime drops whatever does not
+/// fit, so every order event was displacing a fill that a client cannot
+/// reconstruct. See `tests/cases/logs.rs`, which pins both halves of this:
+/// that placing and cancelling log nothing, and that a trade filling enough
+/// orders still loses the tail of its own fills.
+///
+/// `PlaceOrderLog` and `CancelOrderLog` still exist in `logs.rs` for clients
+/// decoding historical transactions; nothing emits them.
 pub(crate) fn process_batch_update_core(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -294,12 +325,6 @@ pub(crate) fn process_batch_update_core(
                         .cancel_order_by_index(hinted_cancel_index, &global_trade_accounts_opts)?;
                 }
             };
-
-            emit_stack(CancelOrderLog {
-                market: *market.key,
-                trader: *payer.key,
-                order_sequence_number: cancel_order_params.order_sequence_number(),
-            })?;
         }
         trader_index
     };
@@ -349,18 +374,6 @@ pub(crate) fn process_batch_update_core(
                 ..
             } = add_order_to_market_result;
 
-            emit_stack(PlaceOrderLog {
-                market: *market.key,
-                trader: *payer.key,
-                base_atoms,
-                price,
-                order_type,
-                is_bid: PodBool::from(place_order_params.is_bid()),
-                _padding: [0; 6],
-                order_sequence_number,
-                order_index,
-                last_valid_slot,
-            })?;
             result.push((order_sequence_number, order_index));
         }
         expand_market_if_needed(&payer, &market)?;

--- a/programs/manifest/tests/cases/logs.rs
+++ b/programs/manifest/tests/cases/logs.rs
@@ -1,0 +1,439 @@
+//! What a batch update writes to the transaction log.
+//!
+//! It emits no event for the orders it places or cancels. Those events told
+//! the sender what it had just asked for, so they were a syscall spent on
+//! information the caller already had, and they displaced fills in a capped
+//! log. Fills are the part a trader cannot predict, so they are still logged.
+//!
+//! That is a statement about placements and cancellations only, not about the
+//! log as a whole: matching still emits whatever it needs to. A global maker
+//! that cannot cover its order produces a `GlobalCleanupLog`, covered below,
+//! and other instructions log as they always did.
+#![cfg_attr(not(feature = "test-sbf"), allow(dead_code, unused_imports))]
+
+use base64::Engine;
+use hypertree::NIL;
+use manifest::{
+    logs::{CancelOrderLog, Discriminant, FillLog, GlobalCleanupLog, PlaceOrderLog},
+    program::{
+        batch_update::{CancelOrderParams, PlaceOrderParams},
+        batch_update_instruction,
+    },
+    state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, OrderType},
+};
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::Instruction;
+use solana_keypair::Keypair;
+use solana_program::pubkey::Pubkey;
+use solana_program_test::tokio;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+use crate::{send_tx_with_retry, TestFixture, Token, SOL_UNIT_SIZE, USDC_UNIT_SIZE};
+
+/// The program data payloads of a simulated transaction, discriminant
+/// included, together with the raw log lines so a caller can see truncation
+/// and the `Program return:` line.
+async fn simulate_program_data(
+    test_fixture: &TestFixture,
+    instructions: Vec<Instruction>,
+) -> (Vec<Vec<u8>>, Vec<String>) {
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair();
+    let mut context = test_fixture.context.borrow_mut();
+    let blockhash = context.get_new_latest_blockhash().await.unwrap();
+    let transaction: Transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&payer),
+        &[&payer_keypair],
+        blockhash,
+    );
+    let simulation = context
+        .banks_client
+        .simulate_transaction(transaction)
+        .await
+        .unwrap();
+    assert!(
+        matches!(simulation.result, Some(Ok(()))),
+        "{:?}",
+        simulation.result
+    );
+    let logs: Vec<String> = simulation.simulation_details.unwrap().logs;
+    let payloads: Vec<Vec<u8>> = logs
+        .iter()
+        .filter_map(|log: &String| log.strip_prefix("Program data: "))
+        .filter_map(|data: &str| base64::engine::general_purpose::STANDARD.decode(data).ok())
+        .collect();
+    (payloads, logs)
+}
+
+/// The return data the runtime writes to the log as `Program return:` when the
+/// instruction exits, decoded. This is a separate channel from the events: it
+/// survives later invocations clearing the structured return data slot,
+/// because it is already in the log by then.
+fn program_return(logs: &[String]) -> Option<Vec<u8>> {
+    logs.iter()
+        .find_map(|line: &String| line.strip_prefix("Program return: "))
+        .and_then(|rest: &str| rest.split_once(' '))
+        .and_then(|(_program_id, data): (&str, &str)| {
+            base64::engine::general_purpose::STANDARD.decode(data).ok()
+        })
+}
+
+/// True for the two events a batch update no longer emits. They still exist
+/// as types so that historical transactions can be decoded.
+fn is_order_event(payload: &[u8]) -> bool {
+    payload.starts_with(&PlaceOrderLog::discriminant())
+        || payload.starts_with(&CancelOrderLog::discriminant())
+}
+
+/// Rests `count` asks from the fixture's second keypair, in batches so that
+/// each transaction fits, and returns nothing: the orders are on the book.
+async fn rest_asks(test_fixture: &mut TestFixture, count: usize) -> anyhow::Result<()> {
+    let maker: Keypair = test_fixture.second_keypair.insecure_clone();
+    let maker_key: Pubkey = maker.pubkey();
+    test_fixture.claim_seat_for_keypair(&maker).await?;
+    test_fixture
+        .deposit_for_keypair(Token::SOL, (count as u64) * SOL_UNIT_SIZE, &maker)
+        .await?;
+    for chunk in (0..count).collect::<Vec<usize>>().chunks(8) {
+        let orders: Vec<PlaceOrderParams> = chunk
+            .iter()
+            .map(|i: &usize| {
+                PlaceOrderParams::new(
+                    SOL_UNIT_SIZE,
+                    1 + *i as u32,
+                    -3,
+                    false,
+                    OrderType::Limit,
+                    NO_EXPIRATION_LAST_VALID_SLOT,
+                )
+            })
+            .collect();
+        send_tx_with_retry(
+            std::rc::Rc::clone(&test_fixture.context),
+            &[batch_update_instruction(
+                &test_fixture.market_fixture.key,
+                &maker_key,
+                None,
+                vec![],
+                orders,
+                None,
+                None,
+                None,
+                None,
+            )],
+            Some(&maker_key),
+            &[&maker],
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// One bid large enough to cross `count` resting asks.
+fn cross_all(test_fixture: &TestFixture, count: usize) -> Instruction {
+    batch_update_instruction(
+        &test_fixture.market_fixture.key,
+        &test_fixture.payer(),
+        None,
+        vec![],
+        vec![PlaceOrderParams::new(
+            (count as u64) * SOL_UNIT_SIZE,
+            100,
+            -3,
+            true,
+            OrderType::Limit,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+        )],
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+/// Program data is only visible in the logs when the compiled program runs
+/// under `test-sbf`; the native processor test runtime drops it.
+#[cfg(feature = "test-sbf")]
+#[tokio::test]
+async fn batch_update_logs_nothing_for_placing_and_cancelling_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+
+    // An ask that rests without crossing anything.
+    let place: Instruction = batch_update_instruction(
+        &test_fixture.market_fixture.key,
+        &test_fixture.payer(),
+        None,
+        vec![],
+        vec![PlaceOrderParams::new(
+            SOL_UNIT_SIZE,
+            5,
+            -3,
+            false,
+            OrderType::Limit,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+        )],
+        None,
+        None,
+        None,
+        None,
+    );
+    let (payloads, _) = simulate_program_data(&test_fixture, vec![place.clone()]).await;
+    assert!(
+        payloads.is_empty(),
+        "placing an order that does not fill logs nothing, got {} payloads",
+        payloads.len(),
+    );
+    send_tx_with_retry(
+        std::rc::Rc::clone(&test_fixture.context),
+        &[place],
+        Some(&test_fixture.payer()),
+        &[&test_fixture.payer_keypair()],
+    )
+    .await?;
+
+    // Cancelling it logs nothing either.
+    let cancel: Instruction = batch_update_instruction(
+        &test_fixture.market_fixture.key,
+        &test_fixture.payer(),
+        None,
+        vec![CancelOrderParams::new(0)],
+        vec![],
+        None,
+        None,
+        None,
+        None,
+    );
+    let (payloads, _) = simulate_program_data(&test_fixture, vec![cancel]).await;
+    assert!(
+        payloads.is_empty(),
+        "cancelling an order logs nothing, got {} payloads",
+        payloads.len(),
+    );
+    Ok(())
+}
+
+/// A batch update that crosses the book emits one `FillLog` per fill, and no
+/// event for the order that did the crossing.
+#[cfg(feature = "test-sbf")]
+#[tokio::test]
+async fn batch_update_logs_every_fill_test() -> anyhow::Result<()> {
+    const RESTING: usize = 24;
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    rest_asks(&mut test_fixture, RESTING).await?;
+    test_fixture.claim_seat().await?;
+    test_fixture
+        .deposit(Token::USDC, 1_000 * USDC_UNIT_SIZE)
+        .await?;
+
+    let (payloads, logs) = simulate_program_data(
+        &test_fixture,
+        vec![
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+            cross_all(&test_fixture, RESTING),
+        ],
+    )
+    .await;
+    let fills: usize = payloads
+        .iter()
+        .filter(|payload: &&Vec<u8>| payload.starts_with(&FillLog::discriminant()))
+        .count();
+    let log_bytes: usize = logs.iter().map(|line: &String| line.len()).sum();
+    println!("LOGS {fills} fills in {log_bytes} bytes of transaction log");
+
+    assert_eq!(fills, RESTING, "every fill is logged");
+    assert!(
+        !payloads
+            .iter()
+            .any(|payload: &Vec<u8>| is_order_event(payload)),
+        "and the order that did the filling is not logged",
+    );
+    // Nothing else happens to log in this scenario: the makers are ordinary
+    // limit orders, so the fills are the whole of it. See the global case
+    // below for matching that does log something else.
+    assert_eq!(payloads.len(), RESTING);
+    Ok(())
+}
+
+/// The orders that rested are still reported, on a different channel: the
+/// runtime writes the instruction's return data into the log as a
+/// `Program return:` line when the program exits. That happens before any
+/// later invocation clears the structured return data slot, so it is readable
+/// from transaction history even though `meta.returnData` ends up holding
+/// whatever ran last, which through the wrapper is its fee transfer.
+///
+/// It is in the log, so it is subject to the same truncation as everything
+/// else there.
+#[cfg(feature = "test-sbf")]
+#[tokio::test]
+async fn the_orders_that_rested_are_in_the_return_log_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+
+    let place: Instruction = batch_update_instruction(
+        &test_fixture.market_fixture.key,
+        &test_fixture.payer(),
+        None,
+        vec![],
+        vec![PlaceOrderParams::new(
+            SOL_UNIT_SIZE,
+            5,
+            -3,
+            false,
+            OrderType::Limit,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+        )],
+        None,
+        None,
+        None,
+        None,
+    );
+    let (payloads, logs) = simulate_program_data(&test_fixture, vec![place]).await;
+
+    assert!(
+        !payloads
+            .iter()
+            .any(|payload: &Vec<u8>| is_order_event(payload)),
+        "the placement is not logged as an event",
+    );
+    let returned: Vec<u8> = program_return(&logs).expect("the return data reaches the log");
+    // Borsh: a u32 count, then (u64 sequence number, u32 order index) each.
+    assert_eq!(
+        u32::from_le_bytes(returned[..4].try_into().unwrap()),
+        1,
+        "one order rested",
+    );
+    assert_eq!(
+        u64::from_le_bytes(returned[4..12].try_into().unwrap()),
+        0,
+        "with sequence number zero, the market's first order",
+    );
+    assert_ne!(
+        u32::from_le_bytes(returned[12..16].try_into().unwrap()),
+        NIL,
+        "and an index on the book",
+    );
+    Ok(())
+}
+
+/// Matching is free to log other things, and does: a global maker that cannot
+/// cover its order is cleaned up during the match and says so. This pins the
+/// narrow claim, that no placement or cancellation event is emitted, against a
+/// batch update whose log is not just fills.
+#[cfg(feature = "test-sbf")]
+#[tokio::test]
+async fn matching_an_unbacked_global_logs_the_cleanup_but_no_order_events_test(
+) -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.global_add_trader().await?;
+    test_fixture.global_deposit(1_000_000).await?;
+
+    // A global bid, then the backing is taken away from under it.
+    test_fixture
+        .batch_update_with_global_for_keypair(
+            None,
+            vec![],
+            vec![PlaceOrderParams::new(
+                100,
+                1,
+                0,
+                true,
+                OrderType::Global,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            &test_fixture.payer_keypair().insecure_clone(),
+        )
+        .await?;
+    test_fixture.global_withdraw(1_000_000).await?;
+    test_fixture.deposit(Token::SOL, 1_000_000).await?;
+
+    // Crossing it finds the global unbacked and cleans it up.
+    let cross: Instruction = batch_update_instruction(
+        &test_fixture.market_fixture.key,
+        &test_fixture.payer(),
+        None,
+        vec![],
+        vec![PlaceOrderParams::new(
+            100,
+            9,
+            -1,
+            false,
+            OrderType::ImmediateOrCancel,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+        )],
+        Some(*test_fixture.market_fixture.market.get_base_mint()),
+        None,
+        Some(*test_fixture.market_fixture.market.get_quote_mint()),
+        None,
+    );
+    let (payloads, _) = simulate_program_data(&test_fixture, vec![cross]).await;
+
+    assert!(
+        payloads
+            .iter()
+            .any(|payload: &Vec<u8>| payload.starts_with(&GlobalCleanupLog::discriminant())),
+        "the cleanup of the unbacked global is logged",
+    );
+    assert!(
+        !payloads
+            .iter()
+            .any(|payload: &Vec<u8>| is_order_event(payload)),
+        "but the order that triggered it still is not",
+    );
+    Ok(())
+}
+
+/// The limit worth knowing about: the transaction log is a fixed byte budget
+/// for the whole transaction, and the runtime drops whatever does not fit, so
+/// a trade that fills enough orders loses the tail of its own fills. Each
+/// `FillLog` is about 310 bytes of base64 once the runtime has framed it, and
+/// the budget is a node setting whose default is 10,000 bytes, so the ceiling
+/// lands around thirty fills in one transaction.
+///
+/// Nothing on chain depends on this, and no fill is lost, only the record of
+/// it: a client that must see every fill has to read the resulting balances or
+/// split the trade across transactions rather than trust the log to be
+/// complete. This is not new, but with the order events gone the fills are the
+/// only thing left in the log, so it is the only place it can bite.
+#[cfg(feature = "test-sbf")]
+#[tokio::test]
+async fn fills_past_the_transaction_log_budget_are_dropped_test() -> anyhow::Result<()> {
+    const RESTING: usize = 40;
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    rest_asks(&mut test_fixture, RESTING).await?;
+    test_fixture.claim_seat().await?;
+    test_fixture
+        .deposit(Token::USDC, 5_000 * USDC_UNIT_SIZE)
+        .await?;
+
+    let (payloads, logs) = simulate_program_data(
+        &test_fixture,
+        vec![
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+            cross_all(&test_fixture, RESTING),
+        ],
+    )
+    .await;
+    let fills: usize = payloads
+        .iter()
+        .filter(|payload: &&Vec<u8>| payload.starts_with(&FillLog::discriminant()))
+        .count();
+    let truncated: bool = logs
+        .iter()
+        .any(|line: &String| line.contains("Log truncated"));
+    let log_bytes: usize = logs.iter().map(|line: &String| line.len()).sum();
+    println!("LOGS {fills} of {RESTING} fills logged in {log_bytes} bytes, truncated {truncated}");
+
+    assert!(
+        fills < RESTING,
+        "this documents that fills are lost once the log budget runs out; if all \
+         {RESTING} were logged the budget grew and the comment above needs revisiting",
+    );
+    assert!(truncated, "the runtime reports the truncation");
+    Ok(())
+}

--- a/programs/manifest/tests/cases/mod.rs
+++ b/programs/manifest/tests/cases/mod.rs
@@ -9,6 +9,7 @@ pub mod exploit_global_reduce;
 pub mod global;
 pub mod global_address;
 pub mod loaders;
+pub mod logs;
 pub mod matching;
 pub mod place_order;
 pub mod reverse;


### PR DESCRIPTION
Every placement and every cancel emitted a sol_log_data event. The trader pays for each one, and each told the client something it already knew: it sent the orders, and the sequence numbers and indices of the ones that rested come back in the instruction's return data. Measured on SBPF v2, dropping them is worth 450 CU on a batch update that places one order, 2,218 on one that places five and 373 on one that cancels one, about 440 CU per order.

The events were also displacing fills. The transaction log is a fixed byte budget for the whole transaction and the runtime drops whatever does not fit, so order events were pushing out records of fills, which are the part a client cannot reconstruct from what it sent.

Fills are still logged. This removes PlaceOrderLog and CancelOrderLog, which nothing emits any more, along with their decoders in the Rust and TypeScript clients and their entries in the IDL. PlaceOrderLogV2 stays because swap still emits it.

This is a breaking change for anything reading manifest's order events. There is no on-chain substitute: a client that needs to know which of its orders rested reads the return data, and one that needs fills reads FillLog.

tests/cases/logs.rs covers what is left: placing and cancelling log nothing, every fill is logged and nothing else is, and, since the fills are now the only thing in the log, the point at which a fill heavy transaction starts losing them.

Also stops zeroing emit_stack's 3000 byte stack buffer before each event, which was a memset for bytes that are immediately overwritten, worth 23 CU on every event the program still emits.