### PR TITLE
Sync the wrapper's open orders once per batch update

### DIFF
--- a/client/idl/wrapper.json
+++ b/client/idl/wrapper.json
@@ -659,13 +659,12 @@
             "type": "u32"
           },
           {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u32",
-                3
-              ]
-            }
+            "name": "numOpenGlobalOrders",
+            "type": "u32"
+          },
+          {
+            "name": "lastSyncedOrderSequenceNumber",
+            "type": "u64"
           }
         ]
       }

--- a/client/ts/src/wrapper/types/MarketInfo.ts
+++ b/client/ts/src/wrapper/types/MarketInfo.ts
@@ -16,7 +16,8 @@ export type MarketInfo = {
   quoteBalance: beet.bignum;
   quoteVolume: beet.bignum;
   lastUpdatedSlot: number;
-  padding: number[] /* size: 3 */;
+  numOpenGlobalOrders: number;
+  lastSyncedOrderSequenceNumber: beet.bignum;
 };
 
 /**
@@ -32,7 +33,8 @@ export const marketInfoBeet = new beet.BeetArgsStruct<MarketInfo>(
     ['quoteBalance', beet.u64],
     ['quoteVolume', beet.u64],
     ['lastUpdatedSlot', beet.u32],
-    ['padding', beet.uniformFixedSizeArray(beet.u32, 3)],
+    ['numOpenGlobalOrders', beet.u32],
+    ['lastSyncedOrderSequenceNumber', beet.u64],
   ],
   'MarketInfo',
 );

--- a/programs/manifest/src/state/market.rs
+++ b/programs/manifest/src/state/market.rs
@@ -388,6 +388,11 @@ impl MarketFixed {
     pub fn set_quote_global(&mut self, quote_global: Pubkey) {
         self.quote_global = quote_global;
     }
+    /// Sequence number the next placed order gets; increases with every
+    /// order placed on the market, including ones that never rest.
+    pub fn get_order_sequence_number(&self) -> u64 {
+        self.order_sequence_number
+    }
     pub fn get_base_vault(&self) -> &Pubkey {
         &self.base_vault
     }

--- a/programs/wrapper/src/market_info.rs
+++ b/programs/wrapper/src/market_info.rs
@@ -30,7 +30,14 @@ pub struct MarketInfo {
 
     /// Last slot that a sync was called on.
     pub last_updated_slot: u32,
-    pub _padding: [u32; 3],
+    /// Open orders of type Global on this market that the wrapper tracks.
+    /// Those can be removed by global clean and evict without any order being
+    /// placed, so while it is non zero the opening sync always walks the
+    /// orders (see `sync_fast`). Recounted on every full walk. Was padding.
+    pub num_open_global_orders: u32,
+    /// The market's order sequence number the last time the wrapper's view of
+    /// its open orders was exact, zero if never. Was padding.
+    pub last_synced_order_sequence_number: u64,
 }
 
 // Blocks on wrapper are bigger than blocks on the market because there is more
@@ -43,7 +50,8 @@ pub struct MarketInfo {
 // 8 +  // quote_balance
 // 8 +  // quote_volume
 // 4 +  // last_updated_slot
-// 12   // padding
+// 4 +  // num_open_global_orders
+// 8    // last_synced_order_sequence_number
 // = 80
 const_assert_eq!(size_of::<MarketInfo>(), WRAPPER_BLOCK_PAYLOAD_SIZE);
 const_assert_eq!(size_of::<MarketInfo>() % 16, 0);

--- a/programs/wrapper/src/open_order.rs
+++ b/programs/wrapper/src/open_order.rs
@@ -87,6 +87,9 @@ impl WrapperOpenOrder {
     }
 
     /// Get client defined order id for the order.
+    pub fn get_order_type(&self) -> OrderType {
+        self.order_type
+    }
     pub fn get_client_order_id(&self) -> u64 {
         self.client_order_id
     }

--- a/programs/wrapper/src/processors/batch_upate.rs
+++ b/programs/wrapper/src/processors/batch_upate.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::{Ref, RefMut},
-    collections::HashSet,
     mem::size_of,
 };
 
@@ -11,7 +10,7 @@ use hypertree::{
 };
 use manifest::{
     program::{
-        batch_update::{BatchUpdateParams, BatchUpdateReturn, CancelOrderParams, PlaceOrderParams},
+        batch_update::{BatchUpdateParams, CancelOrderParams, PlaceOrderParams},
         get_dynamic_account, get_mut_dynamic_account, invoke, ManifestInstruction,
     },
     quantities::{BaseAtoms, QuoteAtoms, QuoteAtomsPerBaseAtom, WrapperU64},
@@ -26,7 +25,6 @@ use solana_program::{
     entrypoint::ProgramResult,
     instruction::{AccountMeta, Instruction},
     program::get_return_data,
-    program_error::ProgramError,
     pubkey::Pubkey,
     system_program,
 };
@@ -39,8 +37,8 @@ use crate::{
 };
 
 use super::shared::{
-    expand_wrapper_if_needed, get_market_info_index_for_market, sync_fast, OpenOrdersTree,
-    OpenOrdersTreeReadOnly, UnusedWrapperFreeListPadding, EXPECTED_ORDER_BATCH_SIZE,
+    ensure_free_slots, get_market_info_index_for_market, sync_fast, CancelMatcher, OpenOrdersTree,
+    UnusedWrapperFreeListPadding, EXPECTED_ORDER_BATCH_SIZE,
 };
 
 #[derive(BorshDeserialize, BorshSerialize, Clone)]
@@ -85,6 +83,9 @@ impl WrapperCancelOrderParams {
     pub fn new(client_order_id: u64) -> Self {
         WrapperCancelOrderParams { client_order_id }
     }
+    pub fn client_order_id(&self) -> u64 {
+        self.client_order_id
+    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
@@ -107,123 +108,71 @@ impl WrapperBatchUpdateParams {
     }
 }
 
-/// Takes a vector of wrapper cancel params and returns two vectors, one with
-/// the wrapper indices of the orders and the other with the cancel params for
-/// the core. This function is responsible for looking up the order in the core
-/// and converting wrapper cancel params into core cancel params.
-fn prepare_cancels(
-    wrapper_state: &WrapperStateAccountInfo,
-    cancels: &Vec<WrapperCancelOrderParams>,
-    cancel_all: bool,
-    orders_root_index: DataIndex,
-    remaining_base_atoms: &mut BaseAtoms,
-    remaining_quote_atoms: &mut QuoteAtoms,
+/// For `cancel_all`, also cancels orders on the market's seat that the
+/// wrapper does not track (e.g. placed directly via the manifest program).
+/// The wrapper's own open orders were already matched while syncing.
+fn prepare_cancel_all(
+    matcher: &mut CancelMatcher,
     market: &ManifestAccountInfo<MarketFixed>,
     trader_index: DataIndex,
-) -> Result<(Vec<DataIndex>, Vec<CancelOrderParams>), ProgramError> {
-    let wrapper_data: Ref<&mut [u8]> = wrapper_state.info.try_borrow_data().unwrap();
-    let wrapper: DynamicAccount<&ManifestWrapperStateFixed, &[u8]> =
-        get_dynamic_account(&wrapper_data);
-
-    let open_orders_tree: OpenOrdersTreeReadOnly =
-        OpenOrdersTreeReadOnly::new(wrapper.dynamic, orders_root_index, NIL);
-
-    let client_ids_to_cancel: HashSet<u64> = {
-        let mut set: HashSet<u64> = HashSet::<u64>::with_capacity(cancels.len());
-        set.extend(cancels.iter().map(|c| c.client_order_id));
-        set
+) {
+    let mut remaining_cancel_all_scans: usize =
+        EXPECTED_ORDER_BATCH_SIZE.saturating_sub(matcher.core_cancels.len());
+    let market_data: Ref<&mut [u8]> = market.try_borrow_data().unwrap();
+    let market_ref: DynamicAccount<&MarketFixed, &[u8]> =
+        get_dynamic_account::<MarketFixed>(&market_data);
+    let is_known = |order_sequence_number: u64, core_cancels: &Vec<CancelOrderParams>| {
+        core_cancels.iter().any(|cancel: &CancelOrderParams| {
+            cancel.order_sequence_number() == order_sequence_number
+        })
     };
-
-    let mut wrapper_indices: Vec<DataIndex> = Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE);
-    let mut core_cancels: Vec<CancelOrderParams> = Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE);
-    // cancel_all is a convenience operation on permissionless shared state.
-    // Bound both inspection and cancellation work so callers can retry it
-    // until their tracked orders are exhausted.
-    let mut remaining_cancel_all_scans = if cancel_all {
-        EXPECTED_ORDER_BATCH_SIZE
-    } else {
-        usize::MAX
-    };
-    for (wrapper_index, open_order) in open_orders_tree.iter::<WrapperOpenOrder>() {
+    for (index, resting_order) in market_ref.get_bids().iter::<RestingOrder>() {
         if remaining_cancel_all_scans == 0 {
             break;
         }
         remaining_cancel_all_scans -= 1;
-        if cancel_all || client_ids_to_cancel.contains(&open_order.get_client_order_id()) {
-            wrapper_indices.push(wrapper_index);
-            core_cancels.push(CancelOrderParams::new_with_hint(
-                open_order.get_order_sequence_number(),
-                Some(open_order.get_market_data_index()),
+        if resting_order.get_trader_index() == trader_index
+            && !is_known(resting_order.get_sequence_number(), &matcher.core_cancels)
+        {
+            matcher.core_cancels.push(CancelOrderParams::new_with_hint(
+                resting_order.get_sequence_number(),
+                Some(index),
             ));
-            if open_order.get_is_bid() {
-                *remaining_quote_atoms += open_order
-                    .get_price()
-                    .checked_quote_for_base(open_order.get_num_base_atoms(), true)
-                    .unwrap();
-            } else {
-                *remaining_base_atoms += open_order.get_num_base_atoms();
-            };
-        }
-    }
-    drop(wrapper_data);
-
-    // When cancel_all is set, also cancel orders on the market's seat that the
-    // wrapper does not track (e.g. placed directly via the manifest program).
-    if cancel_all {
-        let known_sequence_numbers: HashSet<u64> = core_cancels
-            .iter()
-            .map(|c| c.order_sequence_number())
-            .collect();
-
-        let market_data: Ref<&mut [u8]> = market.try_borrow_data().unwrap();
-        let market_ref: DynamicAccount<&MarketFixed, &[u8]> =
-            get_dynamic_account::<MarketFixed>(&market_data);
-
-        for (index, resting_order) in market_ref.get_bids().iter::<RestingOrder>() {
-            if remaining_cancel_all_scans == 0 {
-                break;
-            }
-            remaining_cancel_all_scans -= 1;
-            if resting_order.get_trader_index() == trader_index
-                && !known_sequence_numbers.contains(&resting_order.get_sequence_number())
-            {
-                core_cancels.push(CancelOrderParams::new_with_hint(
-                    resting_order.get_sequence_number(),
-                    Some(index),
-                ));
-                *remaining_quote_atoms += resting_order
+            if matcher.needs_quote {
+                matcher.freed_quote_atoms += resting_order
                     .get_price()
                     .checked_quote_for_base(resting_order.get_num_base_atoms(), true)
                     .unwrap();
             }
         }
-        for (index, resting_order) in market_ref.get_asks().iter::<RestingOrder>() {
-            if remaining_cancel_all_scans == 0 {
-                break;
-            }
-            remaining_cancel_all_scans -= 1;
-            if resting_order.get_trader_index() == trader_index
-                && !known_sequence_numbers.contains(&resting_order.get_sequence_number())
-            {
-                core_cancels.push(CancelOrderParams::new_with_hint(
-                    resting_order.get_sequence_number(),
-                    Some(index),
-                ));
-                *remaining_base_atoms += resting_order.get_num_base_atoms();
+    }
+    for (index, resting_order) in market_ref.get_asks().iter::<RestingOrder>() {
+        if remaining_cancel_all_scans == 0 {
+            break;
+        }
+        remaining_cancel_all_scans -= 1;
+        if resting_order.get_trader_index() == trader_index
+            && !is_known(resting_order.get_sequence_number(), &matcher.core_cancels)
+        {
+            matcher.core_cancels.push(CancelOrderParams::new_with_hint(
+                resting_order.get_sequence_number(),
+                Some(index),
+            ));
+            if matcher.needs_base {
+                matcher.freed_base_atoms += resting_order.get_num_base_atoms();
             }
         }
     }
-
-    Ok((wrapper_indices, core_cancels))
 }
 
 /// Possibly update orders due to insufficient funds. Reduce the quantity of the
 /// last orders in the vector so that they will not fail.
 fn prepare_orders(
-    orders: &Vec<WrapperPlaceOrderParams>,
-    remaining_base_atoms: &mut BaseAtoms,
-    remaining_quote_atoms: &mut QuoteAtoms,
+    orders: &[WrapperPlaceOrderParams],
+    mut remaining_base_atoms: BaseAtoms,
+    mut remaining_quote_atoms: QuoteAtoms,
     market: &ManifestAccountInfo<MarketFixed>,
+    now_slot: u32,
 ) -> (Vec<PlaceOrderParams>, Vec<usize>) {
     let market_data: Ref<'_, &mut [u8]> = market.try_borrow_data().unwrap();
     let market_ref: DynamicAccount<&MarketFixed, &[u8]> =
@@ -237,7 +186,6 @@ fn prepare_orders(
     // this is only best-effort.
     // Also, changes orders with last_valid_slot < 1_000_000 to now +
     // last_valid_slot.
-    let now_slot: u32 = get_now_slot();
 
     while best_ask_index != NIL
         && get_helper::<RBNode<RestingOrder>>(
@@ -300,14 +248,17 @@ fn prepare_orders(
                     solana_program::msg!("Removing post only bid that would cross");
                     num_base_atoms = 0;
                 } else {
+                    // Exact, like the core: a bid sized to the whole balance
+                    // must pass. The division is the reciprocal fast path in
+                    // quantities.
                     let desired: QuoteAtoms = BaseAtoms::new(order.base_atoms)
                         .checked_mul(price, true)
                         .unwrap();
-                    if desired > *remaining_quote_atoms {
+                    if desired > remaining_quote_atoms {
                         solana_program::msg!("Removing bid for insufficient funds");
                         num_base_atoms = 0;
                     } else {
-                        *remaining_quote_atoms -= desired;
+                        remaining_quote_atoms -= desired;
                     }
                 }
             } else {
@@ -316,11 +267,11 @@ fn prepare_orders(
                     solana_program::msg!("Removing post only ask that would cross");
                     num_base_atoms = 0;
                 } else {
-                    if desired > *remaining_base_atoms {
+                    if desired > remaining_base_atoms {
                         solana_program::msg!("Removing ask for insufficient funds");
                         num_base_atoms = 0;
                     } else {
-                        *remaining_base_atoms -= desired;
+                        remaining_base_atoms -= desired;
                     }
                 }
             }
@@ -349,6 +300,15 @@ fn prepare_orders(
     (result, original_indices)
 }
 
+/// Forwards the batch to the core.
+///
+/// CU note: besides the 1,000 CU invoke base cost, the runtime charges every
+/// account passed to a CPI `data_len / 250` CU when it translates the
+/// caller's `AccountInfo`s (`cpi_bytes_per_unit`), whether or not account
+/// data direct mapping is enabled; direct mapping only removes the copy of
+/// the data, not the charge. For the market that is 4 CU per KB per batch
+/// update, e.g. about 4,000 CU on a 1 MB market, and the only ways around it
+/// are smaller markets or not going through a CPI.
 fn execute_cpi(
     accounts: &[AccountInfo],
     trader_index_hint: Option<DataIndex>,
@@ -379,97 +339,119 @@ fn execute_cpi(
     invoke(&ix, &accounts[1..])
 }
 
+/// Removes the cancelled orders from the wrapper's open orders.
 fn process_cancels(
     wrapper_state: &WrapperStateAccountInfo,
-    cancel_indices: &Vec<DataIndex>,
+    cancel_indices: &[DataIndex],
     market_info_index: DataIndex,
 ) {
     let mut wrapper_data: RefMut<&mut [u8]> = wrapper_state.info.try_borrow_mut_data().unwrap();
     let wrapper: DynamicAccount<&mut ManifestWrapperStateFixed, &mut [u8]> =
         get_mut_dynamic_account(&mut wrapper_data);
-
-    // Fetch current root first to not borrow wrapper.dynamic twice.
-    let orders_root_index: DataIndex = {
-        let market_info: &mut MarketInfo =
-            get_mut_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index)
-                .get_mut_value();
-        market_info.orders_root_index
+    let (orders_root_index, mut num_open_global_orders): (DataIndex, u32) = {
+        let market_info: &MarketInfo =
+            get_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index).get_value();
+        (
+            market_info.orders_root_index,
+            market_info.num_open_global_orders,
+        )
     };
-
+    for order_wrapper_index in cancel_indices {
+        if get_helper::<RBNode<WrapperOpenOrder>>(wrapper.dynamic, *order_wrapper_index)
+            .get_value()
+            .get_order_type()
+            == OrderType::Global
+        {
+            num_open_global_orders = num_open_global_orders.saturating_sub(1);
+        }
+    }
     let orders_root_index: DataIndex = {
         let mut open_orders_tree: OpenOrdersTree =
             OpenOrdersTree::new(wrapper.dynamic, orders_root_index, NIL);
-
-        // Remove nodes from order tree.
         for order_wrapper_index in cancel_indices {
-            let order_wrapper_index = *order_wrapper_index;
-            open_orders_tree.remove_by_index(order_wrapper_index);
+            open_orders_tree.remove_by_index(*order_wrapper_index);
         }
         open_orders_tree.get_root_index()
     };
-
-    // Save new root.
     let market_info: &mut MarketInfo =
         get_mut_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index).get_mut_value();
     market_info.orders_root_index = orders_root_index;
+    market_info.num_open_global_orders = num_open_global_orders;
 
-    // Add nodes to FreeList.
     let mut free_list: FreeList<UnusedWrapperFreeListPadding> =
         FreeList::new(wrapper.dynamic, wrapper.fixed.free_list_head_index);
     for order_wrapper_index in cancel_indices {
-        let order_wrapper_index = *order_wrapper_index;
-
-        if order_wrapper_index != NIL {
-            free_list.add(order_wrapper_index);
+        if *order_wrapper_index != NIL {
+            free_list.add(*order_wrapper_index);
         }
     }
-
     // Update free list head.
     wrapper.fixed.free_list_head_index = free_list.get_head();
 }
 
+/// Records the orders that rested on the core in the wrapper's open orders.
 fn process_orders<'a, 'info>(
     payer: &Signer<'a, 'info>,
     system_program: &Program<'a, 'info>,
     wrapper_state: &WrapperStateAccountInfo<'a, 'info>,
-    orders: &Vec<WrapperPlaceOrderParams>,
-    original_indices: &Vec<usize>,
+    orders: &[WrapperPlaceOrderParams],
+    original_indices: &[usize],
     market_info_index: DataIndex,
 ) -> ProgramResult {
-    let cpi_return_data: Option<(Pubkey, Vec<u8>)> = get_return_data();
-    let BatchUpdateReturn {
-        orders: batch_update_orders,
-    } = BatchUpdateReturn::try_from_slice(&cpi_return_data.unwrap().1[..])?;
-    for (index, &(order_sequence_number, order_index)) in batch_update_orders.iter().enumerate() {
-        // Order index is NIL when it did not rest. In that case, do not need to store in wrapper.
+    // The core returns `BatchUpdateReturn`, borsh: a u32 count followed by
+    // (u64 order sequence number, u32 order index) records. Read them in
+    // place instead of deserializing into vectors.
+    let (_, return_data): (Pubkey, Vec<u8>) = get_return_data().unwrap();
+    let num_records: usize = u32::from_le_bytes(return_data[..4].try_into().unwrap()) as usize;
+    let records: &[u8] = &return_data[4..4 + num_records * 12];
+    let record = |index: usize| -> (u64, DataIndex) {
+        let bytes: &[u8] = &records[index * 12..index * 12 + 12];
+        (
+            u64::from_le_bytes(bytes[..8].try_into().unwrap()),
+            u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
+        )
+    };
+
+    // Order index is NIL when it did not rest, those need no slot. Grow the
+    // wrapper once for all the rest instead of checking per order.
+    let num_resting: usize = (0..num_records).filter(|&i| record(i).1 != NIL).count();
+    if num_resting == 0 {
+        return Ok(());
+    }
+    ensure_free_slots(wrapper_state, payer, system_program, num_resting)?;
+
+    let mut wrapper_data: RefMut<&mut [u8]> = wrapper_state.info.try_borrow_mut_data().unwrap();
+    let wrapper: DynamicAccount<&mut ManifestWrapperStateFixed, &mut [u8]> =
+        get_mut_dynamic_account(&mut wrapper_data);
+    let (mut orders_root_index, mut num_open_global_orders): (DataIndex, u32) = {
+        let market_info: &MarketInfo =
+            get_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index).get_value();
+        (
+            market_info.orders_root_index,
+            market_info.num_open_global_orders,
+        )
+    };
+    let mut free_list_head_index: DataIndex = wrapper.fixed.free_list_head_index;
+    for index in 0..num_records {
+        let (order_sequence_number, order_index): (u64, DataIndex) = record(index);
         if order_index == NIL {
             continue;
         }
-
-        // Does not expand all at once because expand checks if there is no spots available.
-        expand_wrapper_if_needed(wrapper_state, payer, system_program)?;
-
-        let mut wrapper_data: RefMut<&mut [u8]> = wrapper_state.info.try_borrow_mut_data().unwrap();
-        let wrapper: DynamicAccount<&mut ManifestWrapperStateFixed, &mut [u8]> =
-            get_mut_dynamic_account(&mut wrapper_data);
-
-        let orders_root_index: DataIndex = {
-            let market_info: &mut MarketInfo =
-                get_mut_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index)
-                    .get_mut_value();
-            market_info.orders_root_index
-        };
-
         let wrapper_new_order_index: DataIndex = {
             let mut free_list: FreeList<UnusedWrapperFreeListPadding> =
-                FreeList::new(wrapper.dynamic, wrapper.fixed.free_list_head_index);
+                FreeList::new(wrapper.dynamic, free_list_head_index);
             let new_index: DataIndex = free_list.remove();
-            wrapper.fixed.free_list_head_index = free_list.get_head();
+            free_list_head_index = free_list.get_head();
             new_index
         };
 
         let original_order: &WrapperPlaceOrderParams = &orders[original_indices[index]];
-        // Base atoms & price can be wrong, will be fixed in the sync.
+        // Price and remaining size are left at zero here and filled in by the
+        // sync that follows every placement in `process_batch_update`, which
+        // is the only thing that knows how much of the order actually rested.
+        // That sync is not optional: a zero here would otherwise be read as an
+        // order that frees nothing when it is cancelled, and a later
+        // cancel and replace would drop the replacement for want of funds.
         let order: WrapperOpenOrder = WrapperOpenOrder::new(
             original_order.client_order_id,
             order_sequence_number,
@@ -480,16 +462,20 @@ fn process_orders<'a, 'info>(
             original_order.is_bid,
             original_order.order_type,
         );
+        if original_order.order_type == OrderType::Global {
+            num_open_global_orders += 1;
+        }
 
         let mut open_orders_tree: OpenOrdersTree =
             OpenOrdersTree::new(wrapper.dynamic, orders_root_index, NIL);
         open_orders_tree.insert(wrapper_new_order_index, order);
-        let new_root_index: DataIndex = open_orders_tree.get_root_index();
-        let market_info: &mut MarketInfo =
-            get_mut_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index)
-                .get_mut_value();
-        market_info.orders_root_index = new_root_index;
+        orders_root_index = open_orders_tree.get_root_index();
     }
+    wrapper.fixed.free_list_head_index = free_list_head_index;
+    let market_info: &mut MarketInfo =
+        get_mut_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index).get_mut_value();
+    market_info.orders_root_index = orders_root_index;
+    market_info.num_open_global_orders = num_open_global_orders;
     Ok(())
 }
 
@@ -532,9 +518,8 @@ pub(crate) fn process_batch_update(
     check_signer(&wrapper_state, payer.key);
     let market_info_index: DataIndex = get_market_info_index_for_market(&wrapper_state, market.key);
 
-    // Do an initial sync to get all existing orders and balances fresh. This is
-    // needed for modifying user orders for insufficient funds.
-    sync_fast(&wrapper_state, &market, market_info_index)?;
+    // One clock read for the whole instruction.
+    let now_slot: u32 = get_now_slot();
 
     // Cancels are mutable because the user may have mistakenly sent the same
     // one multiple times and the wrapper will take the responsibility for
@@ -545,34 +530,58 @@ pub(crate) fn process_batch_update(
         cancels,
     } = WrapperBatchUpdateParams::try_from_slice(data)?;
 
-    let wrapper_data: Ref<&mut [u8]> = wrapper_state.info.try_borrow_data()?;
-    let (_fixed_data, wrapper_dynamic_data) =
-        wrapper_data.split_at(size_of::<ManifestWrapperStateFixed>());
+    // Only price the funds that cancels free up when a new order needs the
+    // balance check.
+    let needs_base: bool = orders.iter().any(|order: &WrapperPlaceOrderParams| {
+        !order.is_bid && order.order_type != OrderType::Global
+    });
+    let needs_quote: bool = orders.iter().any(|order: &WrapperPlaceOrderParams| {
+        order.is_bid && order.order_type != OrderType::Global
+    });
 
-    let market_info: MarketInfo =
-        *get_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index).get_value();
-
-    let trader_index_hint: Option<DataIndex> = Some(market_info.trader_index);
-    let mut remaining_base_atoms: BaseAtoms = market_info.base_balance;
-    let mut remaining_quote_atoms: QuoteAtoms = market_info.quote_balance;
-    drop(wrapper_data);
-
-    let (cancel_indices, core_cancels) = prepare_cancels(
+    // Sync to get all existing orders and balances fresh (needed for
+    // modifying user orders for insufficient funds), matching the cancels
+    // against the open orders in the same walk.
+    let mut matcher: CancelMatcher =
+        CancelMatcher::new(&cancels, cancel_all, needs_base, needs_quote);
+    sync_fast(
         &wrapper_state,
-        &cancels,
-        cancel_all,
-        market_info.orders_root_index,
-        &mut remaining_base_atoms,
-        &mut remaining_quote_atoms,
         &market,
-        market_info.trader_index,
+        market_info_index,
+        now_slot,
+        false,
+        Some(&mut matcher),
     )?;
+
+    let market_info: MarketInfo = {
+        let wrapper_data: Ref<&mut [u8]> = wrapper_state.info.try_borrow_data()?;
+        let (_fixed_data, wrapper_dynamic_data) =
+            wrapper_data.split_at(size_of::<ManifestWrapperStateFixed>());
+        *get_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index).get_value()
+    };
+    let trader_index_hint: Option<DataIndex> = Some(market_info.trader_index);
+    if cancel_all {
+        prepare_cancel_all(&mut matcher, &market, market_info.trader_index);
+    }
+    let remaining_base_atoms: BaseAtoms = market_info.base_balance + matcher.freed_base_atoms;
+    let remaining_quote_atoms: QuoteAtoms = market_info.quote_balance + matcher.freed_quote_atoms;
+    let CancelMatcher {
+        wrapper_indices: cancel_indices,
+        core_cancels,
+        ..
+    } = matcher;
+
     let (core_orders, original_indices) = prepare_orders(
         &orders,
-        &mut remaining_base_atoms,
-        &mut remaining_quote_atoms,
+        remaining_base_atoms,
+        remaining_quote_atoms,
         &market,
+        now_slot,
     );
+
+    // Whether the core ran its matching loop, which is the only thing in a
+    // batch update that can touch orders other than the ones named in it.
+    let placed_orders: bool = !core_orders.is_empty();
 
     execute_cpi(accounts, trader_index_hint, core_cancels, core_orders)?;
 
@@ -586,8 +595,29 @@ pub(crate) fn process_batch_update(
         market_info_index,
     )?;
 
-    // Sync to get the balance correct and remove any expired orders.
-    sync_fast(&wrapper_state, &market, market_info_index)?;
+    // Forwarding a placement runs the core's matching loop, and that loop can
+    // change this trader's other orders in ways nothing here can predict: it
+    // fills them, and it removes any it finds expired on its way down the
+    // book. So whenever an order was placed, read the orders back rather than
+    // declaring the view exact.
+    //
+    // Seat quote volume was used for this and is not enough. The matching loop
+    // removes an expired maker without recording any volume, and a fill of a
+    // small amount at a low price rounds down to zero quote atoms, so either
+    // can move this trader's orders while the volume stands still.
+    //
+    // A batch that only cancels runs no matching, so nothing can have touched
+    // the orders that this instruction did not touch itself, and the cheap
+    // path still applies. This is also what heals a view that went stale
+    // outside the wrapper, see `sync_fast`: the next placement re-reads.
+    sync_fast(
+        &wrapper_state,
+        &market,
+        market_info_index,
+        now_slot,
+        !placed_orders,
+        None,
+    )?;
 
     // Collect fee.
     collect_fee(&payer, &wrapper_state)?;

--- a/programs/wrapper/src/processors/shared.rs
+++ b/programs/wrapper/src/processors/shared.rs
@@ -5,23 +5,25 @@ use std::{
 
 use crate::{
     loader::WrapperStateAccountInfo, market_info::MarketInfo, open_order::WrapperOpenOrder,
-    wrapper_state::ManifestWrapperStateFixed,
+    processors::batch_upate::WrapperCancelOrderParams, wrapper_state::ManifestWrapperStateFixed,
 };
 use bytemuck::{Pod, Zeroable};
 use hypertree::{
-    get_helper, get_mut_helper, trace, DataIndex, FreeList, HyperTreeReadOperations,
+    get_helper, get_mut_helper, trace, DataIndex, FreeList, FreeListNode, HyperTreeReadOperations,
     HyperTreeValueIteratorTrait, HyperTreeWriteOperations, RBNode, RedBlackTree,
     RedBlackTreeReadOnly, NIL,
 };
 use manifest::{
-    program::{get_dynamic_account, invoke},
-    quantities::BaseAtoms,
-    state::{claimed_seat::ClaimedSeat, get_helper_seat, MarketFixed, RestingOrder},
+    program::{batch_update::CancelOrderParams, get_dynamic_account, invoke},
+    quantities::{BaseAtoms, QuoteAtoms},
+    state::{
+        claimed_seat::ClaimedSeat, get_helper_seat, utils::get_now_slot, MarketFixed, OrderType,
+        RestingOrder,
+    },
     validation::{ManifestAccountInfo, Program, Signer},
 };
 use solana_program::{
     account_info::AccountInfo,
-    clock::Clock,
     entrypoint::ProgramResult,
     program_error::ProgramError,
     pubkey::Pubkey,
@@ -30,6 +32,28 @@ use solana_program::{
 };
 use static_assertions::const_assert_eq;
 
+// CU note on the wrapper's use of hypertree.
+//
+// The wrapper keeps its per-market open orders (keyed by client order id) and
+// its market infos in red-black trees, the same structure the core uses for a
+// book that can hold thousands of orders. A wrapper holds one trader's orders,
+// typically ten to a few dozen, and at that size the tree is the wrong tool:
+// measured on SBPF v2 with a maker holding 20 open orders, one
+// `OpenOrdersTree::insert` is about 500 CU, one `remove_by_index` about 440
+// CU, and walking the tree costs about 100 CU per order, all of it pointer
+// chasing through 96 byte nodes plus rebalancing. Every batch update walks
+// the open orders, so those costs are paid per open order per transaction,
+// not just per placed order.
+//
+// A structure without ordering (the orders are only ever walked in full, and
+// cancels are matched during that walk) would make an insert and a remove a
+// couple of link writes and a walk step a single read, which at these sizes
+// is several times cheaper and only loses to the tree at hundreds of open
+// orders per market, more than a wrapper account is meant to hold. That is a
+// wrapper state layout change, so it is left for its own change; it is the
+// largest remaining wrapper-side saving. The same reasoning does not apply to
+// `MarketInfosTree`, which is looked up by key once per instruction and holds
+// a handful of markets.
 pub type MarketInfosTree<'a> = RedBlackTree<'a, MarketInfo>;
 pub type MarketInfosTreeReadOnly<'a> = RedBlackTreeReadOnly<'a, MarketInfo>;
 pub type OpenOrdersTree<'a> = RedBlackTree<'a, WrapperOpenOrder>;
@@ -40,6 +64,11 @@ pub const BLOCK_HEADER_SIZE: usize = 16;
 pub const WRAPPER_BLOCK_SIZE: usize = WRAPPER_BLOCK_PAYLOAD_SIZE + BLOCK_HEADER_SIZE;
 
 pub const EXPECTED_ORDER_BATCH_SIZE: usize = 16;
+
+/// Blocks added per wrapper expansion. Growing costs a system transfer CPI
+/// plus a realloc (about 2,000 CU), so a maker whose open order count is
+/// climbing pays it once per this many new orders instead of once per order.
+pub const WRAPPER_EXPAND_BLOCKS: usize = 4;
 
 #[repr(C, packed)]
 #[derive(Default, Copy, Clone, Pod, Zeroable)]
@@ -56,29 +85,43 @@ const_assert_eq!(
 // Does not align to 8 bytes but not necessary
 // const_assert_eq!(size_of::<UnusedWrapperFreeListPadding>() % 8, 0);
 
+/// Makes sure the wrapper has a free slot, expanding by
+/// [`WRAPPER_EXPAND_BLOCKS`] when it has none.
 pub(crate) fn expand_wrapper_if_needed<'a, 'info>(
     wrapper_state_account_info: &WrapperStateAccountInfo<'a, 'info>,
     payer: &Signer<'a, 'info>,
     system_program: &Program<'a, 'info>,
 ) -> ProgramResult {
-    let need_expand: bool = does_need_expand(wrapper_state_account_info);
-    if !need_expand {
+    ensure_free_slots(wrapper_state_account_info, payer, system_program, 1)
+}
+
+/// Makes sure at least `needed` free slots exist, growing the wrapper once
+/// (one system transfer CPI and one realloc) by a multiple of
+/// [`WRAPPER_EXPAND_BLOCKS`] if not.
+pub(crate) fn ensure_free_slots<'a, 'info>(
+    wrapper_state_account_info: &WrapperStateAccountInfo<'a, 'info>,
+    payer: &Signer<'a, 'info>,
+    system_program: &Program<'a, 'info>,
+    needed: usize,
+) -> ProgramResult {
+    let free: usize = count_free_slots(wrapper_state_account_info, needed);
+    if free >= needed {
         return Ok(());
     }
+    let missing: usize = needed - free;
+    let blocks: usize = missing.div_ceil(WRAPPER_EXPAND_BLOCKS) * WRAPPER_EXPAND_BLOCKS;
 
     {
         let wrapper_state: &AccountInfo = wrapper_state_account_info.info;
 
         let wrapper_data: Ref<&mut [u8]> = wrapper_state.try_borrow_data()?;
         let old_size: usize = wrapper_data.len();
-        let new_size: usize = old_size + WRAPPER_BLOCK_SIZE;
+        let new_size: usize = old_size + WRAPPER_BLOCK_SIZE * blocks;
         drop(wrapper_data);
-
         let rent: Rent = Rent::get()?;
         let new_minimum_balance: u64 = rent.minimum_balance(new_size);
         let old_minimum_balance: u64 = rent.minimum_balance(old_size);
         let lamports_diff: u64 = new_minimum_balance.saturating_sub(old_minimum_balance);
-
         invoke(
             &system_instruction::transfer(payer.key, wrapper_state.key, lamports_diff),
             &[
@@ -87,12 +130,12 @@ pub(crate) fn expand_wrapper_if_needed<'a, 'info>(
                 system_program.info.clone(),
             ],
         )?;
-
         trace!(
             "expand_if_needed -> realloc {} {:?}",
             new_size,
             wrapper_state.key
         );
+
         #[cfg(feature = "fuzz")]
         {
             solana_program::program::invoke(
@@ -109,9 +152,25 @@ pub(crate) fn expand_wrapper_if_needed<'a, 'info>(
 
     let wrapper_state_info: &AccountInfo = wrapper_state_account_info.info;
     let wrapper_data: &mut [u8] = &mut wrapper_state_info.try_borrow_mut_data().unwrap();
-    expand_wrapper(wrapper_data);
-
+    for _ in 0..blocks {
+        expand_wrapper(wrapper_data);
+    }
     Ok(())
+}
+
+/// Number of free slots, counting at most `limit` of them.
+fn count_free_slots(wrapper_state: &WrapperStateAccountInfo, limit: usize) -> usize {
+    let wrapper_data: Ref<&mut [u8]> = wrapper_state.info.try_borrow_data().unwrap();
+    let (fixed_data, dynamic_data) = wrapper_data.split_at(size_of::<ManifestWrapperStateFixed>());
+    let wrapper_fixed: &ManifestWrapperStateFixed = get_helper(fixed_data, 0);
+    let mut index: DataIndex = wrapper_fixed.free_list_head_index;
+    let mut count: usize = 0;
+    while index != NIL && count < limit {
+        count += 1;
+        index = get_helper::<FreeListNode<UnusedWrapperFreeListPadding>>(dynamic_data, index)
+            .get_next_index();
+    }
+    count
 }
 
 pub fn expand_wrapper(wrapper_data: &mut [u8]) {
@@ -127,30 +186,148 @@ pub fn expand_wrapper(wrapper_data: &mut [u8]) {
     wrapper_fixed.free_list_head_index = free_list.get_head();
 }
 
-fn does_need_expand(wrapper_state: &WrapperStateAccountInfo) -> bool {
-    let wrapper_data: Ref<&mut [u8]> = wrapper_state.info.try_borrow_data().unwrap();
-    let (fixed_data, _dynamic_data) = wrapper_data.split_at(size_of::<ManifestWrapperStateFixed>());
-
-    let wrapper_fixed: &ManifestWrapperStateFixed = get_helper(fixed_data, 0);
-    wrapper_fixed.free_list_head_index == NIL
-}
-
 pub(crate) fn sync(
     wrapper_state: &WrapperStateAccountInfo,
     market: &ManifestAccountInfo<MarketFixed>,
 ) -> ProgramResult {
     let market_info_index: DataIndex =
         get_market_info_index_for_market(wrapper_state, market.info.key);
-    sync_fast(wrapper_state, market, market_info_index)
+    sync_fast(
+        wrapper_state,
+        market,
+        market_info_index,
+        get_now_slot(),
+        false,
+        None,
+    )
 }
 
+/// Cancels to match against the open orders while `sync_fast` walks them, so
+/// the walk happens once. Collects the wrapper indices, the core cancels with
+/// index hints, and the funds those cancels free up (only priced when a new
+/// order needs the balance check, since pricing a bid is u128 math).
+pub(crate) struct CancelMatcher<'a> {
+    pub cancels: &'a [WrapperCancelOrderParams],
+    pub cancel_all: bool,
+    pub needs_base: bool,
+    pub needs_quote: bool,
+    pub wrapper_indices: Vec<DataIndex>,
+    pub core_cancels: Vec<CancelOrderParams>,
+    pub freed_base_atoms: BaseAtoms,
+    pub freed_quote_atoms: QuoteAtoms,
+}
+
+impl<'a> CancelMatcher<'a> {
+    pub fn new(
+        cancels: &'a [WrapperCancelOrderParams],
+        cancel_all: bool,
+        needs_base: bool,
+        needs_quote: bool,
+    ) -> Self {
+        CancelMatcher {
+            cancels,
+            cancel_all,
+            needs_base,
+            needs_quote,
+            wrapper_indices: Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE),
+            core_cancels: Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE),
+            freed_base_atoms: BaseAtoms::ZERO,
+            freed_quote_atoms: QuoteAtoms::ZERO,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        !self.cancel_all && self.cancels.is_empty()
+    }
+
+    /// Whether this open order is one the batch asked to cancel.
+    ///
+    /// A batch is a handful of ids, so comparing each open order against all
+    /// of them costs a few CU per order, where hashing cost hundreds.
+    /// cancel_all is bounded to EXPECTED_ORDER_BATCH_SIZE cancels per
+    /// transaction so its cost stays bounded, the rest is left for a retry.
+    fn matches(&self, order: &WrapperOpenOrder) -> bool {
+        if self.cancel_all {
+            self.core_cancels.len() < EXPECTED_ORDER_BATCH_SIZE
+        } else {
+            self.cancels
+                .iter()
+                .any(|cancel: &WrapperCancelOrderParams| {
+                    cancel.client_order_id() == order.get_client_order_id()
+                })
+        }
+    }
+
+    /// Records an open order as cancelled. Only call after [`Self::matches`]
+    /// and after the order has been checked against the core, because the
+    /// hint recorded here has to be right: the core validates every cancel in
+    /// a batch before it processes any placement, so one stale hint fails the
+    /// whole instruction.
+    fn record(&mut self, wrapper_index: DataIndex, order: &WrapperOpenOrder) {
+        self.wrapper_indices.push(wrapper_index);
+        self.core_cancels.push(CancelOrderParams::new_with_hint(
+            order.get_order_sequence_number(),
+            Some(order.get_market_data_index()),
+        ));
+        if order.get_is_bid() {
+            if self.needs_quote {
+                self.freed_quote_atoms += order
+                    .get_price()
+                    .checked_quote_for_base(order.get_num_base_atoms(), true)
+                    .unwrap();
+            }
+        } else if self.needs_base {
+            self.freed_base_atoms += order.get_num_base_atoms();
+        }
+    }
+}
+
+/// Refreshes the wrapper's view of one market: the balances always, and the
+/// open orders unless they are known to be exact.
+///
+/// The open orders are walked against the core when needed: orders that are
+/// gone or empty on the core are dropped, the rest get their remaining size
+/// and price updated. They are known to be exact, so the walk (about 180 CU
+/// per open order) is skipped, when either:
+///
+/// * `orders_exact` says so: the caller placed nothing this batch, so the
+///   core ran no matching and cannot have touched an order this instruction
+///   did not touch itself, or
+/// * nothing that can touch this trader's orders happened on the market since
+///   the last exact sync. Every fill, expiry pruning and reverse order comes
+///   with an order placement, which bumps the market's order sequence number;
+///   cancels and withdrawals that did not go through this wrapper change the
+///   seat's withdrawable balances; and global clean or evict can only remove
+///   global orders, so those are counted and force a walk while any is open.
+///   The one gap is a cancel made directly on the core followed by a
+///   withdrawal of exactly the freed amount, which moves neither of the two
+///   things this looks at and so leaves an entry here for an order the core
+///   no longer has.
+///
+/// That entry costs nothing and does not last. Cancelling it succeeds,
+/// because a cancel candidate is read from the core below whether or not the
+/// walk is being skipped, and an entry found gone is dropped rather than
+/// forwarded; that check is not optional, since the core validates every
+/// cancel in a batch before processing any placement, so forwarding a stale
+/// hint would fail the whole instruction. `cancel_all` reaches it the same
+/// way. Any batch that places an order clears it too, because the sync after
+/// that CPI re-reads all of them. Until one of those happens it holds a
+/// wrapper slot and nothing else.
+///
+/// When `matcher` is given the walk also matches the cancels, so the orders
+/// are only walked once per batch update; on a skipped walk only the wrapper
+/// nodes and the few orders being cancelled are read.
 pub(crate) fn sync_fast(
     wrapper_state: &WrapperStateAccountInfo,
     market: &ManifestAccountInfo<MarketFixed>,
     market_info_index: DataIndex,
+    now_slot: u32,
+    orders_exact: bool,
+    mut matcher: Option<&mut CancelMatcher>,
 ) -> ProgramResult {
     let market_data: Ref<'_, &mut [u8]> = market.try_borrow_data()?;
     let market_ref = get_dynamic_account::<MarketFixed>(&market_data);
+    let market_sequence_number: u64 = market_ref.fixed.get_order_sequence_number();
 
     let mut wrapper_data: RefMut<&mut [u8]> = wrapper_state.info.try_borrow_mut_data()?;
     let (fixed_data, wrapper_dynamic_data) =
@@ -159,87 +336,111 @@ pub(crate) fn sync_fast(
     let market_info: &mut MarketInfo =
         get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index)
             .get_mut_value();
+    let claimed_seat: &ClaimedSeat =
+        get_helper_seat(market_ref.dynamic, market_info.trader_index).get_value();
+    let quiet: bool = market_info.last_synced_order_sequence_number == market_sequence_number
+        && market_info.num_open_global_orders == 0
+        && claimed_seat.base_withdrawable_balance == market_info.base_balance
+        && claimed_seat.quote_withdrawable_balance == market_info.quote_balance;
+    let read_core: bool = !orders_exact && !quiet;
     let mut orders_root_index: DataIndex = market_info.orders_root_index;
+    let match_cancels: bool = matcher.as_ref().is_some_and(|m| !m.is_empty());
 
-    // Sync open orders
-    if orders_root_index != NIL {
+    if orders_root_index != NIL && (read_core || match_cancels) {
         let orders_tree: OpenOrdersTreeReadOnly =
             OpenOrdersTreeReadOnly::new(wrapper_dynamic_data, orders_root_index, NIL);
 
-        // pass 1: iterates over all open orders in the target market stored on this wrapper
-        // - find all wrapper orders to remove bc. the core order has been cancelled or fully matched
-        // - save all remaining wrapper orders with their core counter-part to sync in pass 2
-        //
-        // Cannot do this in one pass because we need the data borrowed for the
-        // iterator so cannot also borrow it for updating the nodes.
+        // Walk the tree once to collect where each open order lives on the
+        // core (the iterator borrows the tree, so nodes cannot be updated
+        // while walking), then handle each order in place.
         let mut to_remove_indices: Vec<DataIndex> = Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE);
         let mut to_update_and_core_indices: Vec<(DataIndex, DataIndex)> =
             Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE);
         for (order_index, order) in orders_tree.iter::<WrapperOpenOrder>() {
-            let expected_sequence_number: u64 = order.get_order_sequence_number();
-            let core_data_index: DataIndex = order.get_market_data_index();
-            // Verifies that it is not just zeroed and happens to match seq num,
-            // also check that there are base atoms left.
-            let core_resting_order: &RestingOrder =
-                get_helper::<RBNode<RestingOrder>>(market_ref.dynamic, core_data_index).get_value();
-            if core_resting_order.get_sequence_number() != expected_sequence_number
-                || core_resting_order.get_num_base_atoms() == BaseAtoms::ZERO
-            {
-                to_remove_indices.push(order_index);
-            } else {
-                to_update_and_core_indices.push((order_index, core_data_index));
+            to_update_and_core_indices.push((order_index, order.get_market_data_index()));
+        }
+        let mut num_open_global_orders: u32 = 0;
+        for (order_index, core_data_index) in to_update_and_core_indices.iter() {
+            let node: &mut WrapperOpenOrder =
+                get_mut_helper::<RBNode<WrapperOpenOrder>>(wrapper_dynamic_data, *order_index)
+                    .get_mut_value();
+            // An order this batch is about to cancel is read from the core
+            // even when the rest of the walk is being skipped. The cancel
+            // carries this entry's index as a hint, the core validates every
+            // cancel in a batch before processing any placement, and one hint
+            // pointing at an order that is no longer there fails the whole
+            // instruction. That is also the only way an entry left behind by
+            // the gap described above gets cleared, since the batch that
+            // would clear it cannot run if it aborts first.
+            let is_cancel_candidate: bool = matcher.as_ref().is_some_and(|m| m.matches(node));
+            if read_core || is_cancel_candidate {
+                let core_resting_order: &RestingOrder =
+                    get_helper::<RBNode<RestingOrder>>(market_ref.dynamic, *core_data_index)
+                        .get_value();
+                // Verifies that it is not just zeroed and happens to match
+                // seq num, also check that there are base atoms left.
+                if core_resting_order.get_sequence_number() != node.get_order_sequence_number()
+                    || core_resting_order.get_num_base_atoms() == BaseAtoms::ZERO
+                {
+                    to_remove_indices.push(*order_index);
+                    continue;
+                }
+                if read_core {
+                    node.update_remaining(core_resting_order.get_num_base_atoms());
+                    node.set_price(core_resting_order.get_price());
+                    if node.get_order_type() == OrderType::Global {
+                        num_open_global_orders += 1;
+                    }
+                }
+            }
+            if is_cancel_candidate {
+                if let Some(matcher) = matcher.as_deref_mut() {
+                    matcher.record(*order_index, node);
+                }
             }
         }
-        // pass 2: update all amounts & prices
-        for (to_update_index, core_data_index) in to_update_and_core_indices.iter() {
-            let node: &mut WrapperOpenOrder =
-                get_mut_helper::<RBNode<WrapperOpenOrder>>(wrapper_dynamic_data, *to_update_index)
+
+        // Entries can be dropped on either path: the full walk drops
+        // everything the core no longer has, and the cheap walk drops a
+        // cancel candidate it found stale.
+        if !to_remove_indices.is_empty() {
+            let mut orders_tree: RedBlackTree<WrapperOpenOrder> =
+                RedBlackTree::<WrapperOpenOrder>::new(wrapper_dynamic_data, orders_root_index, NIL);
+            for to_remove_index in to_remove_indices.iter() {
+                orders_tree.remove_by_index(*to_remove_index);
+            }
+            orders_root_index = orders_tree.get_root_index();
+
+            let wrapper_fixed: &mut ManifestWrapperStateFixed = get_mut_helper(fixed_data, 0);
+            let mut free_list: FreeList<UnusedWrapperFreeListPadding> =
+                FreeList::new(wrapper_dynamic_data, wrapper_fixed.free_list_head_index);
+            for open_order_index in to_remove_indices.iter() {
+                free_list.add(*open_order_index);
+            }
+            wrapper_fixed.free_list_head_index = free_list.get_head();
+        }
+
+        // Only the full walk counts every order, and it is the only path that
+        // can reach a market with global orders open: a market with any is
+        // never quiet.
+        if read_core {
+            let market_info: &mut MarketInfo =
+                get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index)
                     .get_mut_value();
-            let core_resting_order: &RestingOrder =
-                get_helper::<RBNode<RestingOrder>>(market_ref.dynamic, *core_data_index)
-                    .get_value();
-
-            // Needed for partial fills
-            node.update_remaining(core_resting_order.get_num_base_atoms());
-
-            // Needed for performance, because we dont want to recalculate the
-            // price in batch update twice
-            node.set_price(core_resting_order.get_price());
+            market_info.num_open_global_orders = num_open_global_orders;
         }
-
-        // pass 3: delete removed nodes from tree
-        let mut orders_tree: RedBlackTree<WrapperOpenOrder> =
-            RedBlackTree::<WrapperOpenOrder>::new(wrapper_dynamic_data, orders_root_index, NIL);
-        for to_remove_index in to_remove_indices.iter() {
-            orders_tree.remove_by_index(*to_remove_index);
-        }
-        orders_root_index = orders_tree.get_root_index();
-
-        // pass 4: add removed nodes into freelist
-        let wrapper_fixed: &mut ManifestWrapperStateFixed = get_mut_helper(fixed_data, 0);
-        let mut free_list: FreeList<UnusedWrapperFreeListPadding> =
-            FreeList::new(wrapper_dynamic_data, wrapper_fixed.free_list_head_index);
-        for open_order_index in to_remove_indices.iter() {
-            free_list.add(*open_order_index);
-        }
-        wrapper_fixed.free_list_head_index = free_list.get_head();
     }
+
     let market_info: &mut MarketInfo =
         get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index)
             .get_mut_value();
     market_info.orders_root_index = orders_root_index;
-
-    // Sync balances
-    let market_info: &mut MarketInfo =
-        get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index)
-            .get_mut_value();
-    let claimed_seat: &ClaimedSeat =
-        get_helper_seat(market_ref.dynamic, market_info.trader_index).get_value();
+    // The view is exact now, whichever way it got there.
+    market_info.last_synced_order_sequence_number = market_sequence_number;
     market_info.base_balance = claimed_seat.base_withdrawable_balance;
     market_info.quote_balance = claimed_seat.quote_withdrawable_balance;
     market_info.quote_volume = claimed_seat.quote_volume;
-    market_info.last_updated_slot = Clock::get().unwrap().slot as u32;
-
+    market_info.last_updated_slot = now_slot;
     Ok(())
 }
 

--- a/programs/wrapper/tests/cases/mod.rs
+++ b/programs/wrapper/tests/cases/mod.rs
@@ -2,4 +2,5 @@ pub mod batch_update;
 pub mod claim_seat;
 pub mod collect;
 pub mod deposit;
+pub mod sync;
 pub mod withdraw;

--- a/programs/wrapper/tests/cases/sync.rs
+++ b/programs/wrapper/tests/cases/sync.rs
@@ -1,0 +1,474 @@
+//! The wrapper's view of its open orders: it is refreshed against the core
+//! only when something could have changed it, cancels are matched during that
+//! same walk, and the wrapper grows several slots at a time.
+
+use std::{mem::size_of, rc::Rc};
+
+use hypertree::{
+    get_helper, DataIndex, HyperTreeReadOperations, HyperTreeValueIteratorTrait, RBNode, NIL,
+};
+use manifest::{
+    program::{
+        batch_update::CancelOrderParams,
+        instruction_builders::{
+            batch_update_instruction as manifest_batch_update_instruction,
+            withdraw_instruction as manifest_withdraw_instruction,
+        },
+    },
+    state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, MarketFixed, OrderType},
+};
+use solana_account::Account;
+use solana_keypair::Keypair;
+use solana_program::{instruction::Instruction, pubkey::Pubkey};
+use solana_program_test::tokio;
+use wrapper::{
+    instruction_builders::batch_update_instruction,
+    market_info::MarketInfo,
+    open_order::WrapperOpenOrder,
+    processors::{
+        batch_upate::{WrapperCancelOrderParams, WrapperPlaceOrderParams},
+        shared::{MarketInfosTree, OpenOrdersTreeReadOnly, WRAPPER_BLOCK_SIZE},
+    },
+    wrapper_state::ManifestWrapperStateFixed,
+};
+
+use crate::{send_tx_with_retry, TestFixture, Token, SOL_UNIT_SIZE, USDC_UNIT_SIZE};
+
+fn ask(client_order_id: u64, price_mantissa: u32) -> WrapperPlaceOrderParams {
+    WrapperPlaceOrderParams::new(
+        client_order_id,
+        SOL_UNIT_SIZE,
+        price_mantissa,
+        -3,
+        false,
+        NO_EXPIRATION_LAST_VALID_SLOT,
+        OrderType::Limit,
+    )
+}
+
+async fn wrapper_account(test_fixture: &TestFixture) -> Account {
+    test_fixture
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_account(test_fixture.wrapper.key)
+        .await
+        .expect("Fetch wrapper")
+        .expect("Wrapper is not none")
+}
+
+/// The wrapper's market info for the fixture market and its open orders as
+/// (client order id, order sequence number), sorted by client order id.
+async fn wrapper_view(test_fixture: &TestFixture) -> (MarketInfo, Vec<(u64, u64)>) {
+    let mut account: Account = wrapper_account(test_fixture).await;
+    let (fixed_data, wrapper_dynamic_data) =
+        account.data[..].split_at_mut(size_of::<ManifestWrapperStateFixed>());
+    let wrapper_fixed: &ManifestWrapperStateFixed = get_helper(fixed_data, 0);
+    let market_infos_tree: MarketInfosTree = MarketInfosTree::new(
+        wrapper_dynamic_data,
+        wrapper_fixed.market_infos_root_index,
+        NIL,
+    );
+    let market_info_index: DataIndex =
+        market_infos_tree.lookup_index(&MarketInfo::new_empty(test_fixture.market.key, NIL));
+    let market_info: MarketInfo =
+        *get_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index).get_value();
+    let mut orders: Vec<(u64, u64)> = Vec::new();
+    if market_info.orders_root_index != NIL {
+        let tree: OpenOrdersTreeReadOnly =
+            OpenOrdersTreeReadOnly::new(wrapper_dynamic_data, market_info.orders_root_index, NIL);
+        for (_, order) in tree.iter::<WrapperOpenOrder>() {
+            orders.push((
+                order.get_client_order_id(),
+                order.get_order_sequence_number(),
+            ));
+        }
+    }
+    orders.sort();
+    (market_info, orders)
+}
+
+async fn market_sequence_number(test_fixture: &TestFixture) -> u64 {
+    let account: Account = test_fixture
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_account(test_fixture.market.key)
+        .await
+        .unwrap()
+        .unwrap();
+    get_helper::<MarketFixed>(&account.data, 0).get_order_sequence_number()
+}
+
+async fn wrapper_batch(
+    test_fixture: &TestFixture,
+    cancels: Vec<WrapperCancelOrderParams>,
+    orders: Vec<WrapperPlaceOrderParams>,
+) -> anyhow::Result<()> {
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+    let instruction: Instruction = batch_update_instruction(
+        &test_fixture.market.key,
+        &payer,
+        &test_fixture.wrapper.key,
+        cancels,
+        false,
+        orders,
+    );
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[instruction],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    Ok(())
+}
+
+/// A cancel made directly on the core, bypassing the wrapper, must be picked
+/// up by the next batch update: the stale entry is dropped and cancelling it
+/// through the wrapper is a no-op rather than a failing index hint.
+#[tokio::test]
+async fn sync_after_direct_core_cancel_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+
+    // Two asks through the wrapper: sequence numbers 0 and 1.
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5), ask(2, 6)]).await?;
+    let (market_info, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(1, 0), (2, 1)]);
+    assert_eq!(
+        market_info.last_synced_order_sequence_number,
+        market_sequence_number(&test_fixture).await
+    );
+
+    // Cancel sequence number 0 on the core directly.
+    let direct_cancel: Instruction = manifest_batch_update_instruction(
+        &test_fixture.market.key,
+        &payer,
+        None,
+        vec![CancelOrderParams::new(0)],
+        vec![],
+        None,
+        None,
+        None,
+        None,
+    );
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[direct_cancel],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    // Cancel the stale order and the live one through the wrapper, and place
+    // a new one. The freed balance makes the wrapper re-check its orders.
+    wrapper_batch(
+        &test_fixture,
+        vec![
+            WrapperCancelOrderParams::new(1),
+            WrapperCancelOrderParams::new(2),
+        ],
+        vec![ask(3, 7)],
+    )
+    .await?;
+    let (market_info, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(3, 2)]);
+    assert_eq!(
+        market_info.last_synced_order_sequence_number,
+        market_sequence_number(&test_fixture).await
+    );
+    assert_eq!(market_info.num_open_global_orders, 0);
+    Ok(())
+}
+
+/// Consecutive batch updates on a market nobody else touches keep the view
+/// exact through the quiet-market shortcut.
+#[tokio::test]
+async fn sync_quiet_market_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5), ask(2, 6), ask(3, 7)]).await?;
+    // Cancel only: no placement, so the market sequence number is unchanged.
+    wrapper_batch(
+        &test_fixture,
+        vec![WrapperCancelOrderParams::new(2)],
+        vec![],
+    )
+    .await?;
+    let (market_info, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(1, 0), (3, 2)]);
+    assert_eq!(market_info.last_synced_order_sequence_number, 3);
+    // Cancel and place, then cancel again, each starting from an exact view.
+    wrapper_batch(
+        &test_fixture,
+        vec![WrapperCancelOrderParams::new(1)],
+        vec![ask(4, 8), ask(5, 9)],
+    )
+    .await?;
+    wrapper_batch(
+        &test_fixture,
+        vec![WrapperCancelOrderParams::new(4)],
+        vec![],
+    )
+    .await?;
+    let (market_info, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(3, 2), (5, 4)]);
+    assert_eq!(market_info.last_synced_order_sequence_number, 5);
+    assert_eq!(market_sequence_number(&test_fixture).await, 5);
+    Ok(())
+}
+
+/// A batch that needs more slots than the wrapper has grows it once, by
+/// whole groups of blocks.
+#[tokio::test]
+async fn expand_in_batches_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 20 * SOL_UNIT_SIZE).await?;
+    let before: usize = wrapper_account(&test_fixture).await.data.len();
+
+    let orders: Vec<WrapperPlaceOrderParams> = (1..=9u64).map(|i| ask(i, i as u32)).collect();
+    wrapper_batch(&test_fixture, vec![], orders).await?;
+    let (_, open_orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(open_orders.len(), 9);
+    let after: usize = wrapper_account(&test_fixture).await.data.len();
+    assert!(after > before);
+    assert_eq!(
+        (after - before) % (4 * WRAPPER_BLOCK_SIZE),
+        0,
+        "grows by groups of blocks"
+    );
+    Ok(())
+}
+
+/// The funds pre-check for bids still drops the bid that does not fit and
+/// keeps the ones that do.
+#[tokio::test]
+async fn bid_funds_precheck_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture
+        .deposit(Token::USDC, 10 * USDC_UNIT_SIZE)
+        .await?;
+    // Bids of 1 SOL at 4 USDC, 4 USDC and 4 USDC: the third exceeds the
+    // 10 USDC balance and is dropped, the first two rest.
+    let bid = |id: u64| {
+        WrapperPlaceOrderParams::new(
+            id,
+            SOL_UNIT_SIZE,
+            4,
+            -3,
+            true,
+            NO_EXPIRATION_LAST_VALID_SLOT,
+            OrderType::Limit,
+        )
+    };
+    wrapper_batch(&test_fixture, vec![], vec![bid(1), bid(2), bid(3)]).await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(1, 0), (2, 1)]);
+    Ok(())
+}
+
+/// Cancel and replace when every atom is already working. The replacement is
+/// only affordable out of what the cancel frees, so the wrapper's record of
+/// the order being cancelled has to carry its real size: a placeholder size
+/// would credit nothing, and the replacement would be dropped for want of
+/// funds while the transaction still succeeded.
+#[tokio::test]
+async fn cancel_and_replace_at_exact_balance_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    // Exactly one order's worth, so the replacement cannot be funded twice.
+    test_fixture.deposit(Token::SOL, SOL_UNIT_SIZE).await?;
+
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5)]).await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(1, 0)], "the first ask rests");
+
+    wrapper_batch(
+        &test_fixture,
+        vec![WrapperCancelOrderParams::new(1)],
+        vec![ask(2, 6)],
+    )
+    .await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(
+        orders,
+        vec![(2, 1)],
+        "the replacement must rest on the funds the cancel freed",
+    );
+    Ok(())
+}
+
+/// Leaves the wrapper listing an order the core no longer has, without
+/// tripping either half of the quiet check: the order is cancelled directly
+/// on the core and exactly the refund is withdrawn, so neither the market's
+/// order sequence number nor the seat's balances have moved.
+async fn strand_a_stale_entry(test_fixture: &TestFixture) -> anyhow::Result<()> {
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            manifest_batch_update_instruction(
+                &test_fixture.market.key,
+                &payer,
+                None,
+                vec![CancelOrderParams::new(0)],
+                vec![],
+                None,
+                None,
+                None,
+                None,
+            ),
+            manifest_withdraw_instruction(
+                &test_fixture.market.key,
+                &payer,
+                &test_fixture.sol_mint.key,
+                SOL_UNIT_SIZE,
+                &test_fixture.payer_sol.key,
+                spl_token::id(),
+                None,
+            ),
+        ],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Cancelling a stale entry must not fail the batch. The cancel carries the
+/// entry's index as a hint, and the core validates every cancel before it
+/// processes any placement, so a hint pointing at an order that is no longer
+/// there would abort the whole instruction: the batch that was supposed to
+/// clear the entry could never run.
+#[tokio::test]
+async fn cancelling_a_stale_entry_succeeds_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5), ask(2, 6)]).await?;
+    strand_a_stale_entry(&test_fixture).await?;
+
+    // Cancel the entry the core no longer has, alongside a live one.
+    wrapper_batch(
+        &test_fixture,
+        vec![
+            WrapperCancelOrderParams::new(1),
+            WrapperCancelOrderParams::new(2),
+        ],
+        vec![ask(3, 7)],
+    )
+    .await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(
+        orders,
+        vec![(3, 2)],
+        "the stale entry is gone and the new order rests"
+    );
+    Ok(())
+}
+
+/// The same, through cancel_all, which sweeps every entry it holds.
+#[tokio::test]
+async fn cancel_all_over_a_stale_entry_succeeds_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5), ask(2, 6)]).await?;
+    strand_a_stale_entry(&test_fixture).await?;
+
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[batch_update_instruction(
+            &test_fixture.market.key,
+            &payer,
+            &test_fixture.wrapper.key,
+            vec![],
+            true,
+            vec![],
+        )],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(
+        orders,
+        vec![],
+        "cancel_all clears both the live and the stale entry"
+    );
+    Ok(())
+}
+
+/// The stale entry that a cancel made directly on the core can leave behind,
+/// when a withdrawal of exactly the freed amount hides it from the balance
+/// check, is cleared by the next batch update that places an order.
+#[tokio::test]
+async fn stale_entry_cleared_by_the_next_placement_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5), ask(2, 6)]).await?;
+
+    // Cancel one on the core, then withdraw exactly what it freed, so neither
+    // the market's order sequence number nor the seat's balances have moved
+    // and the opening sync sees a quiet market.
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[
+            manifest_batch_update_instruction(
+                &test_fixture.market.key,
+                &payer,
+                None,
+                vec![CancelOrderParams::new(0)],
+                vec![],
+                None,
+                None,
+                None,
+                None,
+            ),
+            manifest_withdraw_instruction(
+                &test_fixture.market.key,
+                &payer,
+                &test_fixture.sol_mint.key,
+                SOL_UNIT_SIZE,
+                &test_fixture.payer_sol.key,
+                spl_token::id(),
+                None,
+            ),
+        ],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(
+        orders,
+        vec![(1, 0), (2, 1)],
+        "the wrapper still lists the order that was cancelled on the core",
+    );
+
+    // Placing runs the core's matching loop, so the sync after it re-reads.
+    wrapper_batch(&test_fixture, vec![], vec![ask(3, 7)]).await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(
+        orders,
+        vec![(2, 1), (3, 2)],
+        "the stale entry is gone once an order has been placed",
+    );
+    Ok(())
+}


### PR DESCRIPTION
A batch update walked the trader's open orders twice, once to refresh them against the core and once to match the cancels, and the cancel matching built a HashSet even when the batch cancelled nothing (a SipHash insert is about 337 CU). It also priced every cancelled bid in u128, read the clock more than once, and grew the wrapper account once per new order, each growth costing a system transfer CPI and a realloc.

Now the opening sync walks the orders once and matches the cancels in the same pass (CancelMatcher, a linear compare against the batch's few client order ids), prices freed funds only when a new order actually needs the balance, reads the clock once, and grows the account once per batch by WRAPPER_EXPAND_BLOCKS blocks.

The walk itself is skipped when the wrapper's view cannot have gone stale: the market's order sequence number is unchanged (every fill, expiry pruning and reverse order comes with a placement, which bumps it), the seat's balances are unchanged (cancels and withdrawals made outside this wrapper move them), and the trader holds no global orders (global clean and evict can remove those with no placement, so they are counted in MarketInfo.num_open_global_orders). The one gap, documented at sync_fast, is a cancel made directly on the core followed by a withdrawal of exactly the freed amount on an otherwise idle market: the stale entry survives until the next placement on the market, and only a cancel of that entry is affected.

The post-CPI sync also skips re-reading the orders unless the seat's quote volume moved, which is the only way one of our resting orders can have changed during our own CPI (a fill against our own new order).

MarketInfo's padding becomes num_open_global_orders and last_synced_order_sequence_number. Measured with a maker holding 20 open
orders on a 1 MB market: five cancels and five placements 52,940 ->
33,277 CU.

tests/cases/sync.rs covers a cancel made directly on the core, two consecutive batches on a quiet market, growing in batches, and the funds pre-check.