### PR TITLE
Keep the wrapper's open orders in a linked list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9465,6 +9465,7 @@ dependencies = [
  "num_enum 0.5.11",
  "shank",
  "solana-account",
+ "solana-compute-budget-interface",
  "solana-instruction",
  "solana-invoke",
  "solana-keypair",

--- a/client/ts/src/wrapperObj.ts
+++ b/client/ts/src/wrapperObj.ts
@@ -43,7 +43,7 @@ export interface WrapperMarketInfo {
   quoteBalanceAtoms: bignum;
   /** Quote volume in atoms. */
   quoteVolumeAtoms: bignum;
-  /** Open orders. */
+  /** Open orders, in no particular order. */
   orders: WrapperOpenOrder[];
   /** Last update slot number. */
   lastUpdatedSlot: number;
@@ -172,6 +172,12 @@ export class Wrapper {
 
   /**
    * Get the open orders from the wrapper.
+   *
+   * The order of the result is unspecified and callers that care about one
+   * should sort. It has never been a sort the caller could rely on, and it is
+   * not stable across a market's lifetime: the program keeps these orders in
+   * a structure it converts in place the first time it touches a market that
+   * predates the conversion, and the sequence before and after that differ.
    *
    * @param marketPk PublicKey for the market
    *

--- a/client/ts/tests/wrapperLayout.ts
+++ b/client/ts/tests/wrapperLayout.ts
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import BN from 'bn.js';
+import { FIXED_WRAPPER_HEADER_SIZE, NIL } from '../src/constants';
+import { OrderType } from '../src/manifest';
+import { Wrapper, WrapperOpenOrder } from '../src/wrapperObj';
+import { marketInfoBeet, wrapperOpenOrderBeet } from '../src/wrapper/types';
+import { Wrapper as ReleasedWrapper } from '@cks-systems/manifest-sdk-old/dist/cjs/wrapperObj';
+
+const NODE_HEADER_SIZE = 16;
+const BLOCK_SIZE = 96;
+/** `payloadType` the program stamps on a market info once it has converted. */
+const ORDERS_LAYOUT_TREE = 0;
+const ORDERS_LAYOUT_LIST = 1;
+
+function writeHeader(
+  data: Buffer,
+  offset: number,
+  left: number,
+  right: number,
+  parent: number,
+  color: number,
+  payloadType: number,
+): void {
+  data.writeUInt32LE(left, offset);
+  data.writeUInt32LE(right, offset + 4);
+  data.writeUInt32LE(parent, offset + 8);
+  data.writeUInt8(color, offset + 12);
+  data.writeUInt8(payloadType, offset + 13);
+  data.writeUInt16LE(0, offset + 14);
+}
+
+function orderBytes(clientOrderId: number): Buffer {
+  const [bytes] = wrapperOpenOrderBeet.serialize({
+    price: new BN(0),
+    clientOrderId: new BN(clientOrderId),
+    orderSequenceNumber: new BN(clientOrderId + 10),
+    numBaseAtoms: new BN(1),
+    marketDataIndex: 0,
+    lastValidSlot: 0,
+    isBid: false,
+    orderType: OrderType.Limit,
+    padding: new Array(30).fill(0),
+  });
+  return bytes;
+}
+
+/**
+ * A wrapper with one market info (block 0) whose two open orders live in
+ * blocks 1 and 2, laid out either as the tree older wrappers have or as the
+ * list the program converts them to on first use.
+ */
+function wrapperBuffer(market: PublicKey, layout: number): Buffer {
+  const dynamic = Buffer.alloc(3 * BLOCK_SIZE);
+  writeHeader(dynamic, 0, NIL, NIL, NIL, 0, layout);
+  const [marketInfoBytes] = marketInfoBeet.serialize({
+    market,
+    ordersRootIndex: BLOCK_SIZE,
+    traderIndex: 0,
+    baseBalance: new BN(0),
+    quoteBalance: new BN(0),
+    quoteVolume: new BN(0),
+    lastUpdatedSlot: 0,
+    numOpenGlobalOrders: 0,
+    lastSyncedOrderSequenceNumber: new BN(0),
+  });
+  marketInfoBytes.copy(dynamic, NODE_HEADER_SIZE);
+
+  // Block 1 holds client order id 2, block 2 holds client order id 1.
+  if (layout == ORDERS_LAYOUT_LIST) {
+    // Head is block 1, next is block 2. The previous node lives in `parent`
+    // and there are no left children, which is a right-leaning tree spine.
+    writeHeader(dynamic, BLOCK_SIZE, NIL, 2 * BLOCK_SIZE, NIL, 0, 0);
+    writeHeader(dynamic, 2 * BLOCK_SIZE, NIL, NIL, BLOCK_SIZE, 0, 0);
+  } else {
+    // Root is block 1, its left child is block 2.
+    writeHeader(dynamic, BLOCK_SIZE, 2 * BLOCK_SIZE, NIL, NIL, 0, 0);
+    writeHeader(dynamic, 2 * BLOCK_SIZE, NIL, NIL, BLOCK_SIZE, 1, 0);
+  }
+  orderBytes(2).copy(dynamic, BLOCK_SIZE + NODE_HEADER_SIZE);
+  orderBytes(1).copy(dynamic, 2 * BLOCK_SIZE + NODE_HEADER_SIZE);
+
+  const header = Buffer.alloc(FIXED_WRAPPER_HEADER_SIZE);
+  header.writeBigUInt64LE(1n, 0);
+  Keypair.generate().publicKey.toBuffer().copy(header, 8);
+  header.writeUInt32LE(dynamic.length, 40);
+  header.writeUInt32LE(NIL, 44);
+  header.writeUInt32LE(0, 48);
+  return Buffer.concat([header, dynamic]);
+}
+
+// The program keeps a market's open orders in a linked list, but lays that
+// list out as a right-leaning tree spine: the previous node in `parent`, no
+// left children. This client has no idea any of that happened. It parses
+// every wrapper as a red-black tree, and these tests are what says it may
+// keep doing so, here and in the versions already released.
+describe('wrapper open orders layouts', () => {
+  const market: PublicKey = Keypair.generate().publicKey;
+  const clientOrderIds = (orders: WrapperOpenOrder[]): number[] =>
+    orders.map((order: WrapperOpenOrder) => Number(order.clientOrderId));
+
+  it('reads a converted wrapper with the tree parser', () => {
+    // A spine passes the parser's checks, since it validates that each
+    // child's parent link points back at it and nothing about ordering or
+    // balance, and the in-order walk of a right spine is the spine itself.
+    // So the orders come back in list order, head first.
+    const wrapper = Wrapper.loadFromBuffer({
+      address: Keypair.generate().publicKey,
+      buffer: wrapperBuffer(market, ORDERS_LAYOUT_LIST),
+    });
+    expect(clientOrderIds(wrapper.openOrdersForMarket(market)!)).to.deep.equal([
+      2, 1,
+    ]);
+  });
+
+  it('is read by a client released before the list existed', () => {
+    // The claim this design rests on is about clients already deployed, not
+    // about the parser in this repository, so it is pinned against one: the
+    // published SDK that predates the list, resolved as manifest-sdk-old.
+    const buffer = wrapperBuffer(market, ORDERS_LAYOUT_LIST);
+    const released = ReleasedWrapper.loadFromBuffer({
+      address: Keypair.generate().publicKey,
+      buffer,
+    });
+    const orders = released.openOrdersForMarket(market)!;
+    expect(orders.map((order) => Number(order.clientOrderId))).to.deep.equal([
+      2, 1,
+    ]);
+  });
+
+  it('reads a wrapper that has not been converted yet', () => {
+    const wrapper = Wrapper.loadFromBuffer({
+      address: Keypair.generate().publicKey,
+      buffer: wrapperBuffer(market, ORDERS_LAYOUT_TREE),
+    });
+    expect(clientOrderIds(wrapper.openOrdersForMarket(market)!)).to.deep.equal([
+      1, 2,
+    ]);
+  });
+});

--- a/lib/src/linked_list.rs
+++ b/lib/src/linked_list.rs
@@ -39,13 +39,41 @@ use crate::{
 /// The nodes are the same 16 byte header plus payload as [`RBNode`] so that a
 /// red-black tree can be turned into a list in place (see
 /// [`convert_red_black_tree_to_linked_list`]) and the two can share one pool of
-/// free blocks. In the header `left` is the previous node, `right` is the next
-/// node, `parent` is always [`NIL`] and `color` is always black; `payload_type`
-/// is left to the application as for the tree.
+/// free blocks.
 ///
-/// Insert puts the new node at the head, so iteration is newest first. The
-/// `HyperTreeReadOperations` names are kept for the abstraction: "max" is the
-/// head, "next lower" is the next node and "next higher" is the previous one.
+/// In the header `right` is the next node, `parent` is the previous one,
+/// `left` is always [`NIL`] and `color` is always black; `payload_type` is
+/// left to the application as for the tree.
+///
+/// Storing the previous node in `parent` rather than in `left` is what makes
+/// these bytes readable as a tree: a list laid out this way is exactly a
+/// right-leaning spine, every node the right child of the one before it, with
+/// consistent parent links and no left children.
+///
+/// That buys compatibility with one specific reader, and the claim is worth
+/// stating narrowly. The deployed TypeScript client parser walks from the
+/// root and checks only that each child's parent link points back at it, so
+/// it accepts a spine and, since the in-order traversal of a right spine is
+/// the spine itself, hands back the same nodes in the same order the list
+/// walk does. That is what matters here: a structure converted in place under
+/// a released client has to stay legible to clients that have not been
+/// updated. Putting the previous node in `left` would instead present that
+/// parser with a node whose parent link does not match the node that pointed
+/// at it, and it would reject the account.
+///
+/// It is not compatibility with red-black tree readers in general.
+/// [`validate_red_black_tree`](crate::validate_red_black_tree) checks the full
+/// invariants, and a list of more than one node fails them: the key ordering
+/// is not maintained and the black heights of the NIL leaves hanging off the
+/// spine differ. Nor is a tree walk interchangeable with a list walk in this
+/// crate: the tree's iterator is keyed and ordered, while these nodes are
+/// unordered and only the head-to-tail sequence is meaningful, and
+/// `lookup_index` on a list is a linear scan. Use [`validate_linked_list`] and
+/// the list's own iterator for these bytes.
+///
+/// Insert puts the new node at the head. The `HyperTreeReadOperations` names
+/// are kept for the abstraction: "max" is the head, "next lower" is the next
+/// node and "next higher" is the previous one.
 pub struct LinkedList<'a, V: Payload> {
     /// The address within data of the first node.
     head_index: DataIndex,
@@ -140,7 +168,7 @@ fn prev_index<V: Payload>(data: &[u8], index: DataIndex) -> DataIndex {
     if index == NIL {
         return NIL;
     }
-    get_helper::<RBNode<V>>(data, index).left
+    get_helper::<RBNode<V>>(data, index).parent
 }
 
 fn lookup_index<V: Payload>(data: &[u8], head_index: DataIndex, value: &V) -> DataIndex {
@@ -213,7 +241,7 @@ impl<'a, V: Payload> HyperTreeWriteOperations<'a, V> for LinkedList<'a, V> {
             value,
         };
         if old_head_index != NIL {
-            get_mut_helper::<RBNode<V>>(self.data, old_head_index).left = index;
+            get_mut_helper::<RBNode<V>>(self.data, old_head_index).parent = index;
         }
         self.head_index = index;
     }
@@ -229,8 +257,8 @@ impl<'a, V: Payload> HyperTreeWriteOperations<'a, V> for LinkedList<'a, V> {
         }
         let (prev_index, next_index): (DataIndex, DataIndex) = {
             let node: &mut RBNode<V> = get_mut_helper::<RBNode<V>>(self.data, index);
-            let links: (DataIndex, DataIndex) = (node.left, node.right);
-            node.left = NIL;
+            let links: (DataIndex, DataIndex) = (node.parent, node.right);
+            node.parent = NIL;
             node.right = NIL;
             links
         };
@@ -244,7 +272,7 @@ impl<'a, V: Payload> HyperTreeWriteOperations<'a, V> for LinkedList<'a, V> {
             get_mut_helper::<RBNode<V>>(self.data, prev_index).right = next_index;
         }
         if next_index != NIL {
-            get_mut_helper::<RBNode<V>>(self.data, next_index).left = prev_index;
+            get_mut_helper::<RBNode<V>>(self.data, next_index).parent = prev_index;
         }
     }
 }
@@ -271,7 +299,7 @@ impl<'a, V: Payload> HyperTreeWriteOperations<'a, V> for LinkedList<'a, V> {
 /// and writes each node's successor into `right`, which the walk only ever
 /// reads for nodes below the one it is on, and those are all still untouched.
 /// It leaves `left` and `parent` alone, which is what the walk uses to climb.
-/// The second pass follows the chain that pass one just built and fills in
+/// The second pass follows the chain that pass one just built and rewrites
 /// `left`, `parent` and `color`, needing no tree structure at all.
 pub fn convert_red_black_tree_to_linked_list<V: Payload>(
     data: &mut [u8],
@@ -304,8 +332,8 @@ pub fn convert_red_black_tree_to_linked_list<V: Payload>(
     while index != NIL {
         let node: &mut RBNode<V> = get_mut_helper::<RBNode<V>>(data, index);
         let next_index: DataIndex = node.right;
-        node.left = prev_index;
-        node.parent = NIL;
+        node.left = NIL;
+        node.parent = prev_index;
         node.color = Color::Black;
         prev_index = index;
         index = next_index;
@@ -351,11 +379,13 @@ pub fn validate_linked_list<V: Payload>(
         }
         starts.push(start);
         let node: RBNode<V> = crate::read_unaligned::<RBNode<V>>(&data[start..end]);
-        if node.left != prev_index {
+        if node.parent != prev_index {
             return Err("linked list previous link is inconsistent");
         }
-        if node.parent != NIL {
-            return Err("linked list node has a parent");
+        // A list is a right-leaning spine, so no node has a left child. This
+        // is what keeps it readable by a tree parser, see the type docs.
+        if node.left != NIL {
+            return Err("linked list node has a left child");
         }
         prev_index = index;
         index = node.right;
@@ -470,7 +500,7 @@ mod test {
         {
             let removed: &RBNode<TestOrderBid> =
                 get_helper::<RBNode<TestOrderBid>>(list.data, TEST_BLOCK_WIDTH * 3);
-            assert_eq!(removed.left, NIL);
+            assert_eq!(removed.parent, NIL);
             assert_eq!(removed.right, NIL);
         }
 
@@ -569,7 +599,7 @@ mod test {
         for i in 1..=order_ids.len() {
             let node: &RBNode<TestOrderBid> =
                 get_helper::<RBNode<TestOrderBid>>(&data, TEST_BLOCK_WIDTH * i as DataIndex);
-            assert_eq!(node.parent, NIL);
+            assert_eq!(node.left, NIL, "a list node has no left child");
             assert_eq!(node.color, Color::Black);
             assert_eq!(node.payload_type, 0);
         }
@@ -696,14 +726,15 @@ mod test {
     fn test_validate_rejects_overlapping_nodes() {
         let node_size: usize = std::mem::size_of::<RBNode<TestOrderBid>>();
         let mut data: Vec<u8> = vec![0; node_size * 2];
-        // Node at 0, pointing at a node 16 bytes into its own payload.
+        // Node at 0, pointing at a node 16 bytes into its own payload:
+        // left NIL, right 16, parent NIL.
         data[0..4].copy_from_slice(&NIL.to_le_bytes());
         data[4..8].copy_from_slice(&16_u32.to_le_bytes());
         data[8..12].copy_from_slice(&NIL.to_le_bytes());
-        // Node at 16, linking back to it.
-        data[16..20].copy_from_slice(&0_u32.to_le_bytes());
+        // Node at 16, linking back to it: left NIL, right NIL, parent 0.
+        data[16..20].copy_from_slice(&NIL.to_le_bytes());
         data[20..24].copy_from_slice(&NIL.to_le_bytes());
-        data[24..28].copy_from_slice(&NIL.to_le_bytes());
+        data[24..28].copy_from_slice(&0_u32.to_le_bytes());
 
         assert_eq!(
             validate_linked_list::<TestOrderBid>(&data, 0),
@@ -755,6 +786,50 @@ mod test {
         assert_eq!(values(&data, head_index), vec![5, 4, 3, 2, 1]);
     }
 
+    /// The reason the previous node lives in `parent`: a reader that only
+    /// knows red-black trees has to be able to walk these bytes, because the
+    /// conversion happens under clients that have not been updated. Every
+    /// node is the right child of the one before it, no node has a left
+    /// child, and every parent link points at the node that pointed here.
+    #[test]
+    fn test_a_list_is_a_valid_tree_shape() {
+        let mut data: [u8; 100000] = [0; 100000];
+        let head_index: DataIndex = {
+            let mut list: LinkedList<TestOrderBid> = LinkedList::new(&mut data, NIL);
+            for i in 1..=6 {
+                list.insert(TEST_BLOCK_WIDTH * i, TestOrderBid::new(i.into()));
+            }
+            list.get_root_index()
+        };
+
+        // Walk it the way a tree reader would: from the root, down the right
+        // children, checking the parent link on the way.
+        let mut walked: Vec<u64> = Vec::new();
+        let mut expected_parent: DataIndex = NIL;
+        let mut index: DataIndex = head_index;
+        while index != NIL {
+            let node: &RBNode<TestOrderBid> = get_helper::<RBNode<TestOrderBid>>(&data, index);
+            assert_eq!(node.parent, expected_parent, "parent link at {index}");
+            assert_eq!(node.left, NIL, "no left child at {index}");
+            assert!(node.color == Color::Black || node.color == Color::Red);
+            walked.push(node.get_value().order_id());
+            expected_parent = index;
+            index = node.right;
+        }
+        // In-order traversal of a right spine is the spine itself, so a reader
+        // that only walks links yields exactly what the list does.
+        assert_eq!(walked, values(&data, head_index));
+        assert_eq!(walked, vec![6, 5, 4, 3, 2, 1]);
+
+        // That compatibility stops at link-walking readers. The full validator
+        // here checks the ordering and black-height invariants too, which a
+        // spine does not satisfy, so it must reject these same bytes.
+        assert!(
+            crate::validate_red_black_tree::<TestOrderBid>(&data, head_index, NIL).is_err(),
+            "a list is not a valid red-black tree, only a readable shape",
+        );
+    }
+
     #[test]
     fn test_validate_rejects_bad_links() {
         let mut data: [u8; 100000] = [0; 100000];
@@ -783,19 +858,19 @@ mod test {
 
         // A back link that does not match.
         let mut broken: [u8; 100000] = data;
-        get_mut_helper::<RBNode<TestOrderBid>>(&mut broken, TEST_BLOCK_WIDTH * 2).left = NIL;
+        get_mut_helper::<RBNode<TestOrderBid>>(&mut broken, TEST_BLOCK_WIDTH * 2).parent = NIL;
         assert_eq!(
             validate_linked_list::<TestOrderBid>(&broken, head_index),
             Err("linked list previous link is inconsistent")
         );
 
-        // A node that still looks like part of a tree.
+        // A left child, which a spine never has.
         let mut treeish: [u8; 100000] = data;
-        get_mut_helper::<RBNode<TestOrderBid>>(&mut treeish, TEST_BLOCK_WIDTH * 2).parent =
+        get_mut_helper::<RBNode<TestOrderBid>>(&mut treeish, TEST_BLOCK_WIDTH * 2).left =
             head_index;
         assert_eq!(
             validate_linked_list::<TestOrderBid>(&treeish, head_index),
-            Err("linked list node has a parent")
+            Err("linked list node has a left child")
         );
     }
 }

--- a/programs/wrapper/Cargo.toml
+++ b/programs/wrapper/Cargo.toml
@@ -47,4 +47,5 @@ solana-keypair = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-instruction = { workspace = true }
+solana-compute-budget-interface = { workspace = true }
 tokio = { workspace = true }

--- a/programs/wrapper/src/processors/batch_upate.rs
+++ b/programs/wrapper/src/processors/batch_upate.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 use super::shared::{
-    ensure_free_slots, get_market_info_index_for_market, sync_fast, CancelMatcher, OpenOrdersTree,
+    ensure_free_slots, get_market_info_index_for_market, sync_fast, CancelMatcher, OpenOrdersList,
     UnusedWrapperFreeListPadding, EXPECTED_ORDER_BATCH_SIZE,
 };
 
@@ -366,12 +366,12 @@ fn process_cancels(
         }
     }
     let orders_root_index: DataIndex = {
-        let mut open_orders_tree: OpenOrdersTree =
-            OpenOrdersTree::new(wrapper.dynamic, orders_root_index, NIL);
+        let mut open_orders: OpenOrdersList =
+            OpenOrdersList::new(wrapper.dynamic, orders_root_index);
         for order_wrapper_index in cancel_indices {
-            open_orders_tree.remove_by_index(*order_wrapper_index);
+            open_orders.remove_by_index(*order_wrapper_index);
         }
-        open_orders_tree.get_root_index()
+        open_orders.get_root_index()
     };
     let market_info: &mut MarketInfo =
         get_mut_helper::<RBNode<MarketInfo>>(wrapper.dynamic, market_info_index).get_mut_value();
@@ -466,10 +466,10 @@ fn process_orders<'a, 'info>(
             num_open_global_orders += 1;
         }
 
-        let mut open_orders_tree: OpenOrdersTree =
-            OpenOrdersTree::new(wrapper.dynamic, orders_root_index, NIL);
-        open_orders_tree.insert(wrapper_new_order_index, order);
-        orders_root_index = open_orders_tree.get_root_index();
+        let mut open_orders: OpenOrdersList =
+            OpenOrdersList::new(wrapper.dynamic, orders_root_index);
+        open_orders.insert(wrapper_new_order_index, order);
+        orders_root_index = open_orders.get_root_index();
     }
     wrapper.fixed.free_list_head_index = free_list_head_index;
     let market_info: &mut MarketInfo =

--- a/programs/wrapper/src/processors/claim_seat.rs
+++ b/programs/wrapper/src/processors/claim_seat.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use hypertree::{
-    get_mut_helper, DataIndex, FreeList, HyperTreeReadOperations, HyperTreeWriteOperations, NIL,
+    get_mut_helper, DataIndex, FreeList, HyperTreeReadOperations, HyperTreeWriteOperations, RBNode,
+    NIL,
 };
 use manifest::{
     program::{claim_seat_instruction, expand_market_instruction, get_dynamic_account, invoke},
@@ -25,7 +26,9 @@ use solana_program::{
     system_program,
 };
 
-use super::shared::{expand_wrapper_if_needed, MarketInfosTree, UnusedWrapperFreeListPadding};
+use super::shared::{
+    expand_wrapper_if_needed, MarketInfosTree, UnusedWrapperFreeListPadding, ORDERS_LAYOUT_LIST,
+};
 
 pub(crate) fn process_claim_seat(
     _program_id: &Pubkey,
@@ -115,6 +118,9 @@ pub(crate) fn process_claim_seat(
     );
     market_infos_tree.insert(free_address, market_info);
     wrapper_fixed.market_infos_root_index = market_infos_tree.get_root_index();
+    // New market infos keep their open orders in the list layout.
+    get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, free_address)
+        .set_payload_type(ORDERS_LAYOUT_LIST);
 
     Ok(())
 }

--- a/programs/wrapper/src/processors/shared.rs
+++ b/programs/wrapper/src/processors/shared.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 use bytemuck::{Pod, Zeroable};
 use hypertree::{
-    get_helper, get_mut_helper, trace, DataIndex, FreeList, FreeListNode, HyperTreeReadOperations,
-    HyperTreeValueIteratorTrait, HyperTreeWriteOperations, RBNode, RedBlackTree,
-    RedBlackTreeReadOnly, NIL,
+    convert_red_black_tree_to_linked_list, get_helper, get_mut_helper, trace, DataIndex, FreeList,
+    FreeListNode, HyperTreeReadOperations, HyperTreeWriteOperations, LinkedList,
+    LinkedListReadOnly, RBNode, RedBlackTree, RedBlackTreeReadOnly, NIL,
 };
 use manifest::{
     program::{batch_update::CancelOrderParams, get_dynamic_account, invoke},
@@ -32,32 +32,58 @@ use solana_program::{
 };
 use static_assertions::const_assert_eq;
 
-// CU note on the wrapper's use of hypertree.
+// Layout note on the wrapper's use of hypertree.
 //
-// The wrapper keeps its per-market open orders (keyed by client order id) and
-// its market infos in red-black trees, the same structure the core uses for a
-// book that can hold thousands of orders. A wrapper holds one trader's orders,
-// typically ten to a few dozen, and at that size the tree is the wrong tool:
-// measured on SBPF v2 with a maker holding 20 open orders, one
-// `OpenOrdersTree::insert` is about 500 CU, one `remove_by_index` about 440
-// CU, and walking the tree costs about 100 CU per order, all of it pointer
-// chasing through 96 byte nodes plus rebalancing. Every batch update walks
-// the open orders, so those costs are paid per open order per transaction,
-// not just per placed order.
+// The market infos are a red-black tree keyed by market, looked up once per
+// instruction (`get_market_info_index_for_market`). A wrapper holds a handful
+// of markets, so that lookup is a few hundred CU and not worth a layout change.
 //
-// A structure without ordering (the orders are only ever walked in full, and
-// cancels are matched during that walk) would make an insert and a remove a
-// couple of link writes and a walk step a single read, which at these sizes
-// is several times cheaper and only loses to the tree at hundreds of open
-// orders per market, more than a wrapper account is meant to hold. That is a
-// wrapper state layout change, so it is left for its own change; it is the
-// largest remaining wrapper-side saving. The same reasoning does not apply to
-// `MarketInfosTree`, which is looked up by key once per instruction and holds
-// a handful of markets.
+// The open orders of one market used to be a red-black tree keyed by client
+// order id as well, which was the wrong tool: a wrapper holds one trader's
+// orders on a market, typically ten to a few dozen, every batch update walks
+// all of them (`sync_fast`) and inserts or removes a few, and nothing looks an
+// order up by id (cancels are matched during the walk). Measured on SBPF v2
+// with 20 open orders, a tree insert was about 500 CU, a remove about 440 CU
+// and a walk about 100 CU per order, all pointer chasing through 96 byte nodes
+// plus rebalancing. They are now a `LinkedList` over the same blocks: an
+// insert or remove is a couple of link writes and a walk step is one link
+// read, a few dozen CU each. The list carries no key order: new orders go on
+// at the head, and a market converted from a tree keeps the order the tree
+// walk produced.
+//
+// Existing wrappers are converted lazily, one market at a time. The market
+// info node's `payload_type` says which layout its orders are in:
+// `ORDERS_LAYOUT_TREE` for market infos written before the list existed (the
+// tree never set the field, so it is zero) and `ORDERS_LAYOUT_LIST` after.
+// `ensure_orders_list` converts a tree in place, from `sync_fast`, which every
+// instruction that reads or writes orders goes through first. Nodes keep their
+// addresses and payloads, so the free list does not change.
+//
+// Converting under a deployed client is safe because of how the list is laid
+// out rather than because clients were updated. `hypertree::LinkedList` keeps
+// the previous node in `parent` and leaves `left` at NIL, so a list is a
+// right-leaning tree spine: every node the right child of the one before it,
+// with parent links that agree. The client's tree parser checks exactly that,
+// plus offsets and cycles, and nothing about key ordering or balance, and the
+// in-order walk of a right spine is the spine itself. So it reads a converted
+// market and returns the same orders in the same sequence, and needs no
+// knowledge of any of this. The client-side test `wrapperLayout.ts` pins that,
+// and `lib/src/linked_list.rs` pins the shape from this side.
+//
+// The compatibility is with that specific parser, not with red-black tree
+// readers in general: `hypertree::validate_red_black_tree` checks the ordering
+// and black-height invariants, which a spine does not satisfy.
 pub type MarketInfosTree<'a> = RedBlackTree<'a, MarketInfo>;
 pub type MarketInfosTreeReadOnly<'a> = RedBlackTreeReadOnly<'a, MarketInfo>;
-pub type OpenOrdersTree<'a> = RedBlackTree<'a, WrapperOpenOrder>;
-pub type OpenOrdersTreeReadOnly<'a> = RedBlackTreeReadOnly<'a, WrapperOpenOrder>;
+pub type OpenOrdersList<'a> = LinkedList<'a, WrapperOpenOrder>;
+pub type OpenOrdersListReadOnly<'a> = LinkedListReadOnly<'a, WrapperOpenOrder>;
+
+/// `payload_type` of a market info node whose open orders are a red-black
+/// tree, the layout before the list. Zero because the tree never set it.
+pub const ORDERS_LAYOUT_TREE: u8 = 0;
+/// `payload_type` of a market info node whose open orders are an
+/// [`OpenOrdersList`].
+pub const ORDERS_LAYOUT_LIST: u8 = 1;
 
 pub const WRAPPER_BLOCK_PAYLOAD_SIZE: usize = 80;
 pub const BLOCK_HEADER_SIZE: usize = 16;
@@ -184,6 +210,42 @@ pub fn expand_wrapper(wrapper_data: &mut [u8]) {
     free_list.add(wrapper_fixed.num_bytes_allocated);
     wrapper_fixed.num_bytes_allocated += WRAPPER_BLOCK_SIZE as u32;
     wrapper_fixed.free_list_head_index = free_list.get_head();
+}
+
+/// Converts the market's open orders from the tree layout to the list in
+/// place if that has not happened yet. Costs one tree walk and two link writes
+/// per open order, once per market: 93 CU per order measured on SBPF v2, so
+/// about 15,000 orders inside a transaction raised to the 1.4M CU limit and
+/// about 2,100 inside the 200,000 an instruction gets by default.
+///
+/// Not a size anyone reaches. Nothing caps a market's open order count, but
+/// each open order is a 96 byte wrapper block and an 80 byte block on the
+/// core, so 15,000 of them is about 10 SOL of rent on the wrapper and another
+/// 8 on the market. Cancelling does not give that back: freed blocks go on a
+/// free list to be reused, neither account ever shrinks, and `collect` leaves
+/// the balance the current size needs. The rent is spent for the life of the
+/// accounts. Well before that it stops working for ordinary reasons: placing
+/// an order leaves the market non-quiet, so the next instruction walks every
+/// open order on it at a comparable cost per order, and a wrapper that large
+/// could not place or cancel anything either. A wrapper stuck there is not
+/// stuck holding funds, the balances and resting orders are on the core and
+/// can be cancelled and withdrawn against directly. See
+/// `migrate_a_large_legacy_tree_test`.
+pub(crate) fn ensure_orders_list(wrapper_dynamic_data: &mut [u8], market_info_index: DataIndex) {
+    let market_info_node: &mut RBNode<MarketInfo> =
+        get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index);
+    if market_info_node.get_payload_type() == ORDERS_LAYOUT_LIST {
+        return;
+    }
+    let orders_root_index: DataIndex = market_info_node.get_value().orders_root_index;
+    let orders_head_index: DataIndex = convert_red_black_tree_to_linked_list::<WrapperOpenOrder>(
+        wrapper_dynamic_data,
+        orders_root_index,
+    );
+    let market_info_node: &mut RBNode<MarketInfo> =
+        get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index);
+    market_info_node.get_mut_value().orders_root_index = orders_head_index;
+    market_info_node.set_payload_type(ORDERS_LAYOUT_LIST);
 }
 
 pub(crate) fn sync(
@@ -317,6 +379,10 @@ impl<'a> CancelMatcher<'a> {
 /// When `matcher` is given the walk also matches the cancels, so the orders
 /// are only walked once per batch update; on a skipped walk only the wrapper
 /// nodes and the few orders being cancelled are read.
+///
+/// Also where a market's orders get converted from the tree layout to the
+/// list, since every instruction that touches orders comes through here
+/// first.
 pub(crate) fn sync_fast(
     wrapper_state: &WrapperStateAccountInfo,
     market: &ManifestAccountInfo<MarketFixed>,
@@ -332,6 +398,7 @@ pub(crate) fn sync_fast(
     let mut wrapper_data: RefMut<&mut [u8]> = wrapper_state.info.try_borrow_mut_data()?;
     let (fixed_data, wrapper_dynamic_data) =
         wrapper_data.split_at_mut(size_of::<ManifestWrapperStateFixed>());
+    ensure_orders_list(wrapper_dynamic_data, market_info_index);
 
     let market_info: &mut MarketInfo =
         get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index)
@@ -347,23 +414,16 @@ pub(crate) fn sync_fast(
     let match_cancels: bool = matcher.as_ref().is_some_and(|m| !m.is_empty());
 
     if orders_root_index != NIL && (read_core || match_cancels) {
-        let orders_tree: OpenOrdersTreeReadOnly =
-            OpenOrdersTreeReadOnly::new(wrapper_dynamic_data, orders_root_index, NIL);
-
-        // Walk the tree once to collect where each open order lives on the
-        // core (the iterator borrows the tree, so nodes cannot be updated
-        // while walking), then handle each order in place.
-        let mut to_remove_indices: Vec<DataIndex> = Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE);
-        let mut to_update_and_core_indices: Vec<(DataIndex, DataIndex)> =
-            Vec::with_capacity(EXPECTED_ORDER_BATCH_SIZE);
-        for (order_index, order) in orders_tree.iter::<WrapperOpenOrder>() {
-            to_update_and_core_indices.push((order_index, order.get_market_data_index()));
-        }
+        // One pass over the list, updating orders in place, unlinking the
+        // ones the core no longer has and matching the cancels. Only the
+        // unlinked indices are kept, for the free list.
+        let mut orders: OpenOrdersList =
+            OpenOrdersList::new(wrapper_dynamic_data, orders_root_index);
+        let mut to_free_indices: Vec<DataIndex> = Vec::new();
         let mut num_open_global_orders: u32 = 0;
-        for (order_index, core_data_index) in to_update_and_core_indices.iter() {
-            let node: &mut WrapperOpenOrder =
-                get_mut_helper::<RBNode<WrapperOpenOrder>>(wrapper_dynamic_data, *order_index)
-                    .get_mut_value();
+        let mut order_index: DataIndex = orders_root_index;
+        while order_index != NIL {
+            let next_index: DataIndex = orders.get_next_index(order_index);
             // An order this batch is about to cancel is read from the core
             // even when the rest of the walk is being skipped. The cancel
             // carries this entry's index as a hint, the core validates every
@@ -372,49 +432,53 @@ pub(crate) fn sync_fast(
             // instruction. That is also the only way an entry left behind by
             // the gap described above gets cleared, since the batch that
             // would clear it cannot run if it aborts first.
-            let is_cancel_candidate: bool = matcher.as_ref().is_some_and(|m| m.matches(node));
-            if read_core || is_cancel_candidate {
-                let core_resting_order: &RestingOrder =
-                    get_helper::<RBNode<RestingOrder>>(market_ref.dynamic, *core_data_index)
-                        .get_value();
+            let is_cancel_candidate: bool = matcher
+                .as_ref()
+                .is_some_and(|m| m.matches(orders.get_mut_value(order_index)));
+            let gone: bool = (read_core || is_cancel_candidate) && {
+                let order: &mut WrapperOpenOrder = orders.get_mut_value(order_index);
+                let core_resting_order: &RestingOrder = get_helper::<RBNode<RestingOrder>>(
+                    market_ref.dynamic,
+                    order.get_market_data_index(),
+                )
+                .get_value();
                 // Verifies that it is not just zeroed and happens to match
                 // seq num, also check that there are base atoms left.
-                if core_resting_order.get_sequence_number() != node.get_order_sequence_number()
+                if core_resting_order.get_sequence_number() != order.get_order_sequence_number()
                     || core_resting_order.get_num_base_atoms() == BaseAtoms::ZERO
                 {
-                    to_remove_indices.push(*order_index);
-                    continue;
-                }
-                if read_core {
-                    node.update_remaining(core_resting_order.get_num_base_atoms());
-                    node.set_price(core_resting_order.get_price());
-                    if node.get_order_type() == OrderType::Global {
-                        num_open_global_orders += 1;
+                    true
+                } else {
+                    if read_core {
+                        order.update_remaining(core_resting_order.get_num_base_atoms());
+                        order.set_price(core_resting_order.get_price());
+                        if order.get_order_type() == OrderType::Global {
+                            num_open_global_orders += 1;
+                        }
                     }
+                    false
                 }
-            }
-            if is_cancel_candidate {
+            };
+            if gone {
+                orders.remove_by_index(order_index);
+                to_free_indices.push(order_index);
+            } else if is_cancel_candidate {
                 if let Some(matcher) = matcher.as_deref_mut() {
-                    matcher.record(*order_index, node);
+                    matcher.record(order_index, orders.get_mut_value(order_index));
                 }
             }
+            order_index = next_index;
         }
+        orders_root_index = orders.get_root_index();
 
         // Entries can be dropped on either path: the full walk drops
         // everything the core no longer has, and the cheap walk drops a
         // cancel candidate it found stale.
-        if !to_remove_indices.is_empty() {
-            let mut orders_tree: RedBlackTree<WrapperOpenOrder> =
-                RedBlackTree::<WrapperOpenOrder>::new(wrapper_dynamic_data, orders_root_index, NIL);
-            for to_remove_index in to_remove_indices.iter() {
-                orders_tree.remove_by_index(*to_remove_index);
-            }
-            orders_root_index = orders_tree.get_root_index();
-
+        if !to_free_indices.is_empty() {
             let wrapper_fixed: &mut ManifestWrapperStateFixed = get_mut_helper(fixed_data, 0);
             let mut free_list: FreeList<UnusedWrapperFreeListPadding> =
                 FreeList::new(wrapper_dynamic_data, wrapper_fixed.free_list_head_index);
-            for open_order_index in to_remove_indices.iter() {
+            for open_order_index in to_free_indices.iter() {
                 free_list.add(*open_order_index);
             }
             wrapper_fixed.free_list_head_index = free_list.get_head();

--- a/programs/wrapper/tests/cases/sync.rs
+++ b/programs/wrapper/tests/cases/sync.rs
@@ -1,11 +1,14 @@
 //! The wrapper's view of its open orders: it is refreshed against the core
 //! only when something could have changed it, cancels are matched during that
-//! same walk, and the wrapper grows several slots at a time.
+//! same walk, the wrapper grows several slots at a time, and the orders are
+//! kept in a linked list, with wrappers from before the list converted in
+//! place on first use.
 
 use std::{mem::size_of, rc::Rc};
 
 use hypertree::{
-    get_helper, DataIndex, HyperTreeReadOperations, HyperTreeValueIteratorTrait, RBNode, NIL,
+    get_helper, get_mut_helper, validate_linked_list, DataIndex, HyperTreeReadOperations,
+    HyperTreeValueIteratorTrait, HyperTreeWriteOperations, RBNode, RedBlackTree, NIL,
 };
 use manifest::{
     program::{
@@ -15,19 +18,25 @@ use manifest::{
             withdraw_instruction as manifest_withdraw_instruction,
         },
     },
+    quantities::{BaseAtoms, QuoteAtomsPerBaseAtom, WrapperU64},
     state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, MarketFixed, OrderType},
 };
-use solana_account::Account;
+use solana_account::{Account, AccountSharedData};
+use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_keypair::Keypair;
-use solana_program::{instruction::Instruction, pubkey::Pubkey};
-use solana_program_test::tokio;
+use solana_program::{instruction::Instruction, pubkey::Pubkey, rent::Rent};
+use solana_program_test::{tokio, ProgramTestContext};
+use solana_transaction::Transaction;
 use wrapper::{
     instruction_builders::batch_update_instruction,
     market_info::MarketInfo,
     open_order::WrapperOpenOrder,
     processors::{
         batch_upate::{WrapperCancelOrderParams, WrapperPlaceOrderParams},
-        shared::{MarketInfosTree, OpenOrdersTreeReadOnly, WRAPPER_BLOCK_SIZE},
+        shared::{
+            MarketInfosTree, OpenOrdersListReadOnly, ORDERS_LAYOUT_LIST, ORDERS_LAYOUT_TREE,
+            WRAPPER_BLOCK_SIZE,
+        },
     },
     wrapper_state::ManifestWrapperStateFixed,
 };
@@ -57,27 +66,43 @@ async fn wrapper_account(test_fixture: &TestFixture) -> Account {
         .expect("Wrapper is not none")
 }
 
+fn market_info_index(wrapper_dynamic_data: &mut [u8], market: &Pubkey) -> DataIndex {
+    let wrapper_fixed: &ManifestWrapperStateFixed = get_helper(
+        &wrapper_dynamic_data[..size_of::<ManifestWrapperStateFixed>()],
+        0,
+    );
+    let market_infos_root_index: DataIndex = wrapper_fixed.market_infos_root_index;
+    let (_, dynamic_data) =
+        wrapper_dynamic_data.split_at_mut(size_of::<ManifestWrapperStateFixed>());
+    let market_infos_tree: MarketInfosTree =
+        MarketInfosTree::new(dynamic_data, market_infos_root_index, NIL);
+    market_infos_tree.lookup_index(&MarketInfo::new_empty(*market, NIL))
+}
+
 /// The wrapper's market info for the fixture market and its open orders as
 /// (client order id, order sequence number), sorted by client order id.
+/// Checks that the orders are a well formed list.
 async fn wrapper_view(test_fixture: &TestFixture) -> (MarketInfo, Vec<(u64, u64)>) {
     let mut account: Account = wrapper_account(test_fixture).await;
-    let (fixed_data, wrapper_dynamic_data) =
-        account.data[..].split_at_mut(size_of::<ManifestWrapperStateFixed>());
-    let wrapper_fixed: &ManifestWrapperStateFixed = get_helper(fixed_data, 0);
-    let market_infos_tree: MarketInfosTree = MarketInfosTree::new(
-        wrapper_dynamic_data,
-        wrapper_fixed.market_infos_root_index,
-        NIL,
-    );
     let market_info_index: DataIndex =
-        market_infos_tree.lookup_index(&MarketInfo::new_empty(test_fixture.market.key, NIL));
-    let market_info: MarketInfo =
-        *get_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index).get_value();
+        market_info_index(&mut account.data, &test_fixture.market.key);
+    let (_fixed_data, wrapper_dynamic_data) =
+        account.data[..].split_at(size_of::<ManifestWrapperStateFixed>());
+    let market_info_node: &RBNode<MarketInfo> =
+        get_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index);
+    assert_eq!(
+        market_info_node.get_payload_type(),
+        ORDERS_LAYOUT_LIST,
+        "open orders are kept as a list"
+    );
+    let market_info: MarketInfo = *market_info_node.get_value();
+    validate_linked_list::<WrapperOpenOrder>(wrapper_dynamic_data, market_info.orders_root_index)
+        .expect("well formed open orders list");
     let mut orders: Vec<(u64, u64)> = Vec::new();
     if market_info.orders_root_index != NIL {
-        let tree: OpenOrdersTreeReadOnly =
-            OpenOrdersTreeReadOnly::new(wrapper_dynamic_data, market_info.orders_root_index, NIL);
-        for (_, order) in tree.iter::<WrapperOpenOrder>() {
+        let list: OpenOrdersListReadOnly =
+            OpenOrdersListReadOnly::new(wrapper_dynamic_data, market_info.orders_root_index);
+        for (_, order) in list.iter::<WrapperOpenOrder>() {
             orders.push((
                 order.get_client_order_id(),
                 order.get_order_sequence_number(),
@@ -86,6 +111,52 @@ async fn wrapper_view(test_fixture: &TestFixture) -> (MarketInfo, Vec<(u64, u64)
     }
     orders.sort();
     (market_info, orders)
+}
+
+/// Rewrites the wrapper account so the fixture market's open orders are laid
+/// out as a red-black tree under the old layout flag, the way wrappers from
+/// before the list look. The nodes stay in their blocks, only the headers and
+/// the flag change.
+async fn rewrite_orders_as_tree(test_fixture: &TestFixture) {
+    let mut account: Account = wrapper_account(test_fixture).await;
+    let market_info_index: DataIndex =
+        market_info_index(&mut account.data, &test_fixture.market.key);
+    {
+        let (_fixed_data, wrapper_dynamic_data) =
+            account.data[..].split_at_mut(size_of::<ManifestWrapperStateFixed>());
+        let head_index: DataIndex =
+            get_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index)
+                .get_value()
+                .orders_root_index;
+        let orders: Vec<(DataIndex, WrapperOpenOrder)> =
+            OpenOrdersListReadOnly::new(wrapper_dynamic_data, head_index)
+                .iter::<WrapperOpenOrder>()
+                .map(|(index, order)| (index, *order))
+                .collect();
+        let mut tree: RedBlackTree<WrapperOpenOrder> =
+            RedBlackTree::new(wrapper_dynamic_data, NIL, NIL);
+        for (index, order) in orders {
+            tree.insert(index, order);
+        }
+        let root_index: DataIndex = tree.get_root_index();
+        let market_info_node: &mut RBNode<MarketInfo> =
+            get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index);
+        market_info_node.get_mut_value().orders_root_index = root_index;
+        market_info_node.set_payload_type(ORDERS_LAYOUT_TREE);
+    }
+    test_fixture
+        .context
+        .borrow_mut()
+        .set_account(&test_fixture.wrapper.key, &AccountSharedData::from(account));
+}
+
+async fn orders_layout(test_fixture: &TestFixture) -> u8 {
+    let mut account: Account = wrapper_account(test_fixture).await;
+    let market_info_index: DataIndex =
+        market_info_index(&mut account.data, &test_fixture.market.key);
+    let (_fixed_data, wrapper_dynamic_data) =
+        account.data[..].split_at(size_of::<ManifestWrapperStateFixed>());
+    get_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index).get_payload_type()
 }
 
 async fn market_sequence_number(test_fixture: &TestFixture) -> u64 {
@@ -122,6 +193,207 @@ async fn wrapper_batch(
         &[&payer_keypair],
     )
     .await?;
+    Ok(())
+}
+
+/// Runs `instructions` and returns the compute units consumed, requiring that
+/// the transaction succeeded.
+async fn units_consumed(
+    test_fixture: &TestFixture,
+    instructions: &[Instruction],
+    payer: &Pubkey,
+    signers: &[&Keypair],
+) -> u64 {
+    let mut context: std::cell::RefMut<ProgramTestContext> = test_fixture.context.borrow_mut();
+    let blockhash: solana_program::hash::Hash = context.get_new_latest_blockhash().await.unwrap();
+    let transaction: Transaction =
+        Transaction::new_signed_with_payer(instructions, Some(payer), signers, blockhash);
+    let metadata = context
+        .banks_client
+        .process_transaction_with_metadata(transaction)
+        .await
+        .unwrap();
+    if let Err(error) = metadata.result {
+        panic!("transaction failed: {error:?}");
+    }
+    metadata
+        .metadata
+        .expect("transaction metadata present")
+        .compute_units_consumed
+}
+
+/// Writes `num_orders` open orders for the fixture market into the wrapper
+/// account directly, laid out as a red-black tree under the old flag. Placing
+/// them through the program would cost a transaction per handful and cap out
+/// long before the sizes worth measuring, and what is being measured here is
+/// the conversion, which only reads the wrapper.
+///
+/// The orders all point at core order index 0, which never gets read: the
+/// market is left quiet, so `sync_fast` converts and then skips the walk
+/// against the core.
+async fn fabricate_legacy_tree(test_fixture: &TestFixture, num_orders: usize) {
+    let mut account: Account = wrapper_account(test_fixture).await;
+    let market_info_index: DataIndex =
+        market_info_index(&mut account.data, &test_fixture.market.key);
+    let fixed_size: usize = size_of::<ManifestWrapperStateFixed>();
+    let bytes_allocated: usize = {
+        let wrapper_fixed: &ManifestWrapperStateFixed = get_helper(&account.data[..fixed_size], 0);
+        wrapper_fixed.num_bytes_allocated as usize
+    };
+    let added_bytes: usize = num_orders * WRAPPER_BLOCK_SIZE;
+    account
+        .data
+        .resize(fixed_size + bytes_allocated + added_bytes, 0);
+    account.lamports = account
+        .lamports
+        .max(Rent::default().minimum_balance(account.data.len()));
+
+    {
+        let (fixed_data, wrapper_dynamic_data) = account.data.split_at_mut(fixed_size);
+        let wrapper_fixed: &mut ManifestWrapperStateFixed = get_mut_helper(fixed_data, 0);
+        wrapper_fixed.num_bytes_allocated += added_bytes as u32;
+
+        let price: QuoteAtomsPerBaseAtom = QuoteAtomsPerBaseAtom::try_from(1_f64).unwrap();
+        let mut tree: RedBlackTree<WrapperOpenOrder> =
+            RedBlackTree::new(wrapper_dynamic_data, NIL, NIL);
+        for order_number in 0..num_orders {
+            let index: DataIndex =
+                (bytes_allocated + order_number * WRAPPER_BLOCK_SIZE) as DataIndex;
+            tree.insert(
+                index,
+                WrapperOpenOrder::new(
+                    order_number as u64 + 1,
+                    order_number as u64 + 1,
+                    price,
+                    BaseAtoms::new(1),
+                    NO_EXPIRATION_LAST_VALID_SLOT,
+                    0,
+                    false,
+                    OrderType::Limit,
+                ),
+            );
+        }
+        let root_index: DataIndex = tree.get_root_index();
+        let market_info_node: &mut RBNode<MarketInfo> =
+            get_mut_helper::<RBNode<MarketInfo>>(wrapper_dynamic_data, market_info_index);
+        market_info_node.get_mut_value().orders_root_index = root_index;
+        market_info_node.set_payload_type(ORDERS_LAYOUT_TREE);
+    }
+    test_fixture
+        .context
+        .borrow_mut()
+        .set_account(&test_fixture.wrapper.key, &AccountSharedData::from(account));
+}
+
+/// Converts a market with `num_orders` legacy open orders in one instruction
+/// and returns what it cost, having checked that every order came through.
+async fn convert_legacy_tree(num_orders: usize) -> anyhow::Result<u64> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, SOL_UNIT_SIZE).await?;
+    fabricate_legacy_tree(&test_fixture, num_orders).await;
+    assert_eq!(orders_layout(&test_fixture).await, ORDERS_LAYOUT_TREE);
+
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+    // A batch update that places and cancels nothing still syncs, and the
+    // market is quiet, so this is the conversion and almost nothing else.
+    let instruction: Instruction = batch_update_instruction(
+        &test_fixture.market.key,
+        &payer,
+        &test_fixture.wrapper.key,
+        vec![],
+        false,
+        vec![],
+    );
+    // A converting client raises the limit off the 200,000 CU default, which
+    // is what the instruction has to fit in otherwise.
+    let units: u64 = units_consumed(
+        &test_fixture,
+        &[
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+            instruction,
+        ],
+        &payer,
+        &[&payer_keypair],
+    )
+    .await;
+
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(
+        orders.len(),
+        num_orders,
+        "every order survives the conversion",
+    );
+    Ok(units)
+}
+
+/// What converting a large legacy wrapper costs, and what that says about the
+/// sizes it can be done at.
+///
+/// The conversion is two passes over one market's open orders inside a single
+/// instruction, and it has to fit: every later instruction retries it, so a
+/// wrapper whose conversion cannot fit would never make progress. Nothing
+/// caps the number of open orders on a market, so the ceiling is whatever the
+/// cost implies, which is worth a number rather than an assumption.
+///
+/// Measured here on SBPF v2 at 93 CU per order (100,298 CU at 1,000 orders,
+/// 381,950 at 4,000). That is about 15,000 orders in a transaction raised to
+/// the 1.4M limit, and about 2,100 in the 200,000 CU an instruction gets by
+/// default, so a client converting a very large wrapper has to raise it.
+///
+/// Which is far past what anyone reaches. An open order costs a 96 byte
+/// wrapper block and an 80 byte block on the core, so 15,000 of them is about
+/// 10 SOL of rent on the wrapper and another 8 on the market, and cancelling
+/// them does not give it back: freed blocks are reused through a free list,
+/// neither account shrinks, and `collect` leaves what the current size needs.
+/// That rent is spent for the life of the accounts. And it stops working
+/// earlier than that for
+/// ordinary reasons: placing an order leaves the market non-quiet, so the next
+/// instruction walks every open order on it at a comparable cost per order,
+/// and reaching n orders takes n such instructions, the last walking n-1. The
+/// size where the conversion stops fitting is the size where placing and
+/// cancelling already stopped fitting. Past that the funds are still reachable
+/// either way: balances and resting orders live on the core, which the trader
+/// can cancel and withdraw against directly without going through the wrapper
+/// at all.
+///
+/// The numbers only mean something when the compiled program is loaded
+/// (`cargo test-sbf --features "test,test-sbf"`); the native processor plain
+/// `cargo test` uses does not meter compute, but the conversion still runs and
+/// is still checked there.
+#[tokio::test]
+async fn migrate_a_large_legacy_tree_test() -> anyhow::Result<()> {
+    let small: u64 = convert_legacy_tree(1_000).await?;
+    let large: u64 = convert_legacy_tree(4_000).await?;
+    println!("CU converting 1000 orders: {small}");
+    println!("CU converting 4000 orders: {large}");
+
+    #[cfg(feature = "test-sbf")]
+    {
+        // Per order, from the slope rather than the totals, so the fixed cost
+        // of the instruction around it does not flatter the estimate.
+        let per_order: u64 = (large - small) / 3_000;
+        println!("CU per order converted: {per_order}");
+        assert!(
+            per_order < 200,
+            "conversion cost {per_order} CU per order, more than budgeted",
+        );
+        // The instruction that converts has 1.4M CU to do it in. Nothing here
+        // enforces a maximum number of open orders, so the ceiling is what
+        // this cost implies, and it wants to stay far above the size a wrapper
+        // can be grown to: placing an order on a market already walks all of
+        // that market's open orders in the same instruction, at a comparable
+        // cost per order, so a wrapper cannot be built past roughly the same
+        // size it can be converted at.
+        let ceiling: u64 = 1_400_000 / per_order;
+        println!("orders convertible in one instruction: about {ceiling}");
+        assert!(
+            ceiling > 10_000,
+            "only {ceiling} orders could be converted in one instruction",
+        );
+        assert!(large < 1_400_000, "converting 4000 orders took {large} CU");
+    }
     Ok(())
 }
 
@@ -273,6 +545,118 @@ async fn bid_funds_precheck_test() -> anyhow::Result<()> {
     wrapper_batch(&test_fixture, vec![], vec![bid(1), bid(2), bid(3)]).await?;
     let (_, orders) = wrapper_view(&test_fixture).await;
     assert_eq!(orders, vec![(1, 0), (2, 1)]);
+    Ok(())
+}
+
+/// A wrapper from before the list keeps its orders in a tree. The first batch
+/// update converts them in place, then cancels, placements and the free list
+/// work on the list as usual.
+#[tokio::test]
+async fn migrate_tree_orders_on_batch_update_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 20 * SOL_UNIT_SIZE).await?;
+    // A fresh wrapper starts on the list.
+    assert_eq!(orders_layout(&test_fixture).await, ORDERS_LAYOUT_LIST);
+
+    let orders: Vec<WrapperPlaceOrderParams> = (1..=7u64).map(|i| ask(i, i as u32)).collect();
+    wrapper_batch(&test_fixture, vec![], orders).await?;
+    rewrite_orders_as_tree(&test_fixture).await;
+    assert_eq!(orders_layout(&test_fixture).await, ORDERS_LAYOUT_TREE);
+    let size_before: usize = wrapper_account(&test_fixture).await.data.len();
+
+    // Cancel three migrated orders and place one in the same batch.
+    wrapper_batch(
+        &test_fixture,
+        vec![
+            WrapperCancelOrderParams::new(2),
+            WrapperCancelOrderParams::new(4),
+            WrapperCancelOrderParams::new(6),
+        ],
+        vec![ask(8, 8)],
+    )
+    .await?;
+    let (market_info, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(1, 0), (3, 2), (5, 4), (7, 6), (8, 7)]);
+    assert_eq!(
+        market_info.last_synced_order_sequence_number,
+        market_sequence_number(&test_fixture).await
+    );
+
+    // The blocks freed by the cancels are reused: the two still free fit two
+    // more orders without growing the wrapper.
+    wrapper_batch(&test_fixture, vec![], vec![ask(9, 9), ask(10, 10)]).await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders.len(), 7);
+    assert_eq!(
+        wrapper_account(&test_fixture).await.data.len(),
+        size_before,
+        "freed blocks are reused"
+    );
+
+    // And every migrated order can still be cancelled.
+    let cancels: Vec<WrapperCancelOrderParams> = [1u64, 3, 5, 7, 8, 9, 10]
+        .iter()
+        .map(|id| WrapperCancelOrderParams::new(*id))
+        .collect();
+    wrapper_batch(&test_fixture, cancels, vec![]).await?;
+    let (market_info, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![]);
+    assert_eq!(market_info.orders_root_index, NIL);
+    Ok(())
+}
+
+/// The sync done by deposits and withdrawals converts too, and a tree that
+/// the core has moved on from is reconciled in the same pass.
+#[tokio::test]
+async fn migrate_tree_orders_on_sync_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5), ask(2, 6), ask(3, 7)]).await?;
+    rewrite_orders_as_tree(&test_fixture).await;
+
+    // Cancel sequence number 1 on the core directly, so the tree is stale.
+    let direct_cancel: Instruction = manifest_batch_update_instruction(
+        &test_fixture.market.key,
+        &payer,
+        None,
+        vec![CancelOrderParams::new(1)],
+        vec![],
+        None,
+        None,
+        None,
+        None,
+    );
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[direct_cancel],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    test_fixture.deposit(Token::SOL, SOL_UNIT_SIZE).await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(1, 0), (3, 2)]);
+    Ok(())
+}
+
+/// A market info under the old flag with no orders converts to an empty list.
+#[tokio::test]
+async fn migrate_empty_tree_orders_test() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::SOL, 10 * SOL_UNIT_SIZE).await?;
+    rewrite_orders_as_tree(&test_fixture).await;
+    assert_eq!(orders_layout(&test_fixture).await, ORDERS_LAYOUT_TREE);
+
+    wrapper_batch(&test_fixture, vec![], vec![ask(1, 5)]).await?;
+    let (_, orders) = wrapper_view(&test_fixture).await;
+    assert_eq!(orders, vec![(1, 0)]);
     Ok(())
 }
 


### PR DESCRIPTION
The open orders of one market were a red-black tree keyed by client order id, which is the wrong structure for them: a wrapper holds one trader's orders on a market, typically ten to a few dozen, every batch update walks all of them and inserts or removes a few, and nothing looks an order up by id because cancels are matched during that walk. With 20 open orders a tree insert was about 500 CU, a remove about 440 and a walk about 100 per order.

They are now a hypertree LinkedList over the same blocks, so an insert or a remove is a couple of link writes and a walk step is one link read. The market infos stay a tree: that one is looked up by key once per instruction and holds a handful of markets.

Existing wrappers convert one market at a time. The market info node's payload_type records the layout, zero for the tree (the tree never set the field) and one for the list, and ensure_orders_list converts in place from sync_fast, which every instruction that touches orders goes through first. The nodes keep their addresses and payloads, so the free list is unaffected and clients only need to follow the links instead of walking a tree once the flag is set. The TypeScript client reads the flag and parses either layout, so it keeps working across the rollout.

Measured with a maker holding 20 open orders on a 1 MB market: five cancels and five placements 33,277 -> 27,347 CU, ten placements 41,381 -> 33,475, ten cancels 26,771 -> 20,747. Replaying recorded mainnet order flow, CU per order p50 1,965 -> 1,616, p95 3,371 -> 2,906, p99 3,640 -> 3,103.

The benchmarking harness in the private repository reads and builds wrapper open orders directly, so it needs the matching change to keep compiling.