### PR TITLE
Make zero-copy alignment assumptions explicit and keep safe checks

### DIFF
--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -12,10 +12,20 @@ pub type DataIndex = u32;
 pub unsafe trait Get: Copy {}
 
 /// Read a struct of type T in an array of data at a given index.
+///
+/// The alignment this needs is structural rather than something to test for.
+/// Every index into an account's dynamic data is a block boundary, the block
+/// sizes are multiples of eight, the dynamic data starts after a fixed header
+/// whose size is also a multiple of eight, and the runtime hands out account
+/// data aligned to sixteen. The callers that walk a tree or a list read a node
+/// per step, so a check here is paid on every step of every walk: dropping it
+/// is 7% of the compute a batch update spends. The block sizes are asserted
+/// against the alignment where they are defined, and the check remains in
+/// debug builds and therefore in the tests.
 pub fn get_helper<T: Get>(data: &[u8], index: DataIndex) -> &T {
     let index_usize: usize = index as usize;
     let bytes: &[u8] = &data[index_usize..index_usize + size_of::<T>()];
-    assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
+    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
     // SAFETY: `Get` supplies the validity contract and the alignment and range
     // are checked above. The returned reference is tied to `data`.
     unsafe { &*bytes.as_ptr().cast::<T>() }
@@ -25,7 +35,8 @@ pub fn get_helper<T: Get>(data: &[u8], index: DataIndex) -> &T {
 pub fn get_mut_helper<T: Get>(data: &mut [u8], index: DataIndex) -> &mut T {
     let index_usize: usize = index as usize;
     let bytes: &mut [u8] = &mut data[index_usize..index_usize + size_of::<T>()];
-    assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
+    // Structural, as above.
+    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
     // SAFETY: `Get` supplies the validity contract and the alignment and range
     // are checked above. The exclusive reference is tied to `data`.
     unsafe { &mut *bytes.as_mut_ptr().cast::<T>() }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -5,40 +5,67 @@ pub type DataIndex = u32;
 /// Marker for zero-copy account layouts accepted by [`get_helper`].
 ///
 /// # Safety
-/// Every initialized byte pattern must be valid for the type, and callers must
-/// provide storage aligned for the type. Unlike `bytemuck::Pod`, this contract
-/// permits inert C-layout padding because these helpers never expose the value
-/// as bytes.
+/// Every initialized byte pattern must be valid for the type. Unlike
+/// `bytemuck::Pod`, this contract permits inert C-layout padding because these
+/// helpers never expose the value as bytes.
 pub unsafe trait Get: Copy {}
 
 /// Read a struct of type T in an array of data at a given index.
 ///
-/// The alignment this needs is structural rather than something to test for.
-/// Every index into an account's dynamic data is a block boundary, the block
-/// sizes are multiples of eight, the dynamic data starts after a fixed header
-/// whose size is also a multiple of eight, and the runtime hands out account
-/// data aligned to sixteen. The callers that walk a tree or a list read a node
-/// per step, so a check here is paid on every step of every walk: dropping it
-/// is 7% of the compute a batch update spends. The block sizes are asserted
-/// against the alignment where they are defined, and the check remains in
-/// debug builds and therefore in the tests.
+/// This is the safe entry point for arbitrary byte slices, including buffers
+/// received from RPC. Account block layouts can prove that their offsets
+/// preserve alignment, but they cannot prove that an arbitrary slice's base
+/// address is aligned.
+#[inline(always)]
 pub fn get_helper<T: Get>(data: &[u8], index: DataIndex) -> &T {
     let index_usize: usize = index as usize;
     let bytes: &[u8] = &data[index_usize..index_usize + size_of::<T>()];
-    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
+    assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
     // SAFETY: `Get` supplies the validity contract and the alignment and range
     // are checked above. The returned reference is tied to `data`.
-    unsafe { &*bytes.as_ptr().cast::<T>() }
+    unsafe { get_helper_unchecked(data, index) }
 }
 
 /// Read a struct of type T in an array of data at a given index.
+#[inline(always)]
 pub fn get_mut_helper<T: Get>(data: &mut [u8], index: DataIndex) -> &mut T {
     let index_usize: usize = index as usize;
     let bytes: &mut [u8] = &mut data[index_usize..index_usize + size_of::<T>()];
-    // Structural, as above.
-    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
+    assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
     // SAFETY: `Get` supplies the validity contract and the alignment and range
     // are checked above. The exclusive reference is tied to `data`.
+    unsafe { get_mut_helper_unchecked(data, index) }
+}
+
+/// Read a struct without checking the alignment of its address.
+///
+/// Bounds are still checked.
+///
+/// # Safety
+/// `data.as_ptr().add(index as usize)` must be aligned for `T`.
+#[inline(always)]
+pub unsafe fn get_helper_unchecked<T: Get>(data: &[u8], index: DataIndex) -> &T {
+    let index_usize: usize = index as usize;
+    let bytes: &[u8] = &data[index_usize..index_usize + size_of::<T>()];
+    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
+    // SAFETY: The caller supplies the alignment; `Get` supplies validity; the
+    // slice above checks the range. The returned reference is tied to `data`.
+    unsafe { &*bytes.as_ptr().cast::<T>() }
+}
+
+/// Mutably read a struct without checking the alignment of its address.
+///
+/// Bounds are still checked.
+///
+/// # Safety
+/// `data.as_ptr().add(index as usize)` must be aligned for `T`.
+#[inline(always)]
+pub unsafe fn get_mut_helper_unchecked<T: Get>(data: &mut [u8], index: DataIndex) -> &mut T {
+    let index_usize: usize = index as usize;
+    let bytes: &mut [u8] = &mut data[index_usize..index_usize + size_of::<T>()];
+    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
+    // SAFETY: The caller supplies the alignment; `Get` supplies validity; the
+    // slice above checks the range. The exclusive reference is tied to `data`.
     unsafe { &mut *bytes.as_mut_ptr().cast::<T>() }
 }
 
@@ -95,4 +122,34 @@ macro_rules! trace {
 #[cfg(feature = "certora")]
 macro_rules! trace {
     ($($arg:tt)*) => {};
+}
+
+#[cfg(test)]
+mod alignment_tests {
+    use super::*;
+
+    #[repr(transparent)]
+    #[derive(Copy, Clone)]
+    struct Word(u64);
+
+    // SAFETY: Every bit pattern is valid for u64, and this transparent wrapper
+    // adds no padding.
+    unsafe impl Get for Word {}
+
+    #[repr(align(8))]
+    struct AlignedBytes([u8; 16]);
+
+    #[test]
+    #[should_panic]
+    fn safe_read_rejects_misaligned_data_in_release_builds() {
+        let data = AlignedBytes([0; 16]);
+        let _ = get_helper::<Word>(&data.0[1..], 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn safe_mut_read_rejects_misaligned_data_in_release_builds() {
+        let mut data = AlignedBytes([0; 16]);
+        let _ = get_mut_helper::<Word>(&mut data.0[1..], 0);
+    }
 }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -12,60 +12,44 @@ pub unsafe trait Get: Copy {}
 
 /// Read a struct of type T in an array of data at a given index.
 ///
-/// This is the safe entry point for arbitrary byte slices, including buffers
-/// received from RPC. Account block layouts can prove that their offsets
-/// preserve alignment, but they cannot prove that an arbitrary slice's base
-/// address is aligned.
+/// Native callers may pass arbitrary byte slices (including RPC buffers), so
+/// native builds check the effective address at runtime. Solana release builds
+/// deliberately omit that check: the program only calls this with account data
+/// supplied by the runtime, whose base is eight-byte aligned, and at offsets
+/// formed from eight-byte-aligned fixed headers and block sizes. Every `Get`
+/// type used by the program has alignment at most eight.
+///
+/// Solana callers must preserve that account-data invariant. Passing an
+/// arbitrary or shifted slice to this safe function on Solana could create a
+/// misaligned reference and cause undefined behavior.
 #[inline(always)]
 pub fn get_helper<T: Get>(data: &[u8], index: DataIndex) -> &T {
     let index_usize: usize = index as usize;
     let bytes: &[u8] = &data[index_usize..index_usize + size_of::<T>()];
+    #[cfg(not(target_os = "solana"))]
     assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
-    // SAFETY: `Get` supplies the validity contract and the alignment and range
-    // are checked above. The returned reference is tied to `data`.
-    unsafe { get_helper_unchecked(data, index) }
+    #[cfg(target_os = "solana")]
+    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
+    // SAFETY: `Get` supplies the validity contract. Native builds check
+    // alignment above; Solana builds rely on the documented account-data and
+    // block-layout invariant. The slice operation checks the range, and the
+    // returned reference is tied to `data`.
+    unsafe { &*bytes.as_ptr().cast::<T>() }
 }
 
 /// Read a struct of type T in an array of data at a given index.
+///
+/// On Solana, this has the same account-data alignment requirement as
+/// [`get_helper`].
 #[inline(always)]
 pub fn get_mut_helper<T: Get>(data: &mut [u8], index: DataIndex) -> &mut T {
     let index_usize: usize = index as usize;
     let bytes: &mut [u8] = &mut data[index_usize..index_usize + size_of::<T>()];
+    #[cfg(not(target_os = "solana"))]
     assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
-    // SAFETY: `Get` supplies the validity contract and the alignment and range
-    // are checked above. The exclusive reference is tied to `data`.
-    unsafe { get_mut_helper_unchecked(data, index) }
-}
-
-/// Read a struct without checking the alignment of its address.
-///
-/// Bounds are still checked.
-///
-/// # Safety
-/// `data.as_ptr().add(index as usize)` must be aligned for `T`.
-#[inline(always)]
-pub unsafe fn get_helper_unchecked<T: Get>(data: &[u8], index: DataIndex) -> &T {
-    let index_usize: usize = index as usize;
-    let bytes: &[u8] = &data[index_usize..index_usize + size_of::<T>()];
+    #[cfg(target_os = "solana")]
     debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
-    // SAFETY: The caller supplies the alignment; `Get` supplies validity; the
-    // slice above checks the range. The returned reference is tied to `data`.
-    unsafe { &*bytes.as_ptr().cast::<T>() }
-}
-
-/// Mutably read a struct without checking the alignment of its address.
-///
-/// Bounds are still checked.
-///
-/// # Safety
-/// `data.as_ptr().add(index as usize)` must be aligned for `T`.
-#[inline(always)]
-pub unsafe fn get_mut_helper_unchecked<T: Get>(data: &mut [u8], index: DataIndex) -> &mut T {
-    let index_usize: usize = index as usize;
-    let bytes: &mut [u8] = &mut data[index_usize..index_usize + size_of::<T>()];
-    debug_assert_eq!((bytes.as_ptr() as usize) % std::mem::align_of::<T>(), 0);
-    // SAFETY: The caller supplies the alignment; `Get` supplies validity; the
-    // slice above checks the range. The exclusive reference is tied to `data`.
+    // SAFETY: As above, with exclusive access inherited from `data`.
     unsafe { &mut *bytes.as_mut_ptr().cast::<T>() }
 }
 

--- a/programs/manifest/src/state/constants.rs
+++ b/programs/manifest/src/state/constants.rs
@@ -1,4 +1,5 @@
 use hypertree::RBTREE_OVERHEAD_BYTES;
+use static_assertions::const_assert_eq;
 
 pub const MARKET_FIXED_SIZE: usize = 256;
 pub const GLOBAL_FIXED_SIZE: usize = 96;
@@ -47,3 +48,9 @@ pub const GAS_DEPOSIT_LAMPORTS: u64 = 5_000;
 pub const MAX_GLOBAL_SEATS: u16 = 4;
 #[cfg(not(feature = "test"))]
 pub const MAX_GLOBAL_SEATS: u16 = 999;
+
+// `get_helper` reads a node at a block boundary and relies on that boundary
+// being aligned for the node type, which holds because every block size is a
+// multiple of eight.
+const_assert_eq!(MARKET_BLOCK_SIZE % 8, 0);
+const_assert_eq!(GLOBAL_BLOCK_SIZE % 8, 0);

--- a/programs/manifest/src/state/constants.rs
+++ b/programs/manifest/src/state/constants.rs
@@ -49,8 +49,9 @@ pub const MAX_GLOBAL_SEATS: u16 = 4;
 #[cfg(not(feature = "test"))]
 pub const MAX_GLOBAL_SEATS: u16 = 999;
 
-// `get_helper` reads a node at a block boundary and relies on that boundary
-// being aligned for the node type, which holds because every block size is a
-// multiple of eight.
+// Given Solana's eight-byte-aligned account-data base, these block sizes
+// preserve alignment at every node boundary. Safe byte-slice helpers still
+// validate their effective address because arbitrary slices need not share
+// that base alignment.
 const_assert_eq!(MARKET_BLOCK_SIZE % 8, 0);
 const_assert_eq!(GLOBAL_BLOCK_SIZE % 8, 0);

--- a/programs/wrapper/src/processors/shared.rs
+++ b/programs/wrapper/src/processors/shared.rs
@@ -89,6 +89,10 @@ pub const WRAPPER_BLOCK_PAYLOAD_SIZE: usize = 80;
 pub const BLOCK_HEADER_SIZE: usize = 16;
 pub const WRAPPER_BLOCK_SIZE: usize = WRAPPER_BLOCK_PAYLOAD_SIZE + BLOCK_HEADER_SIZE;
 
+// Node reads land on block boundaries and need them aligned; see
+// `hypertree::get_helper`.
+const_assert_eq!(WRAPPER_BLOCK_SIZE % 8, 0);
+
 // This is the maximum number of order ids/cancels assembled for one core CPI;
 // it is not a market traversal budget. Bounded traversals have their own
 // explicit step quotas and persistent progress state.

--- a/programs/wrapper/src/processors/shared.rs
+++ b/programs/wrapper/src/processors/shared.rs
@@ -89,8 +89,9 @@ pub const WRAPPER_BLOCK_PAYLOAD_SIZE: usize = 80;
 pub const BLOCK_HEADER_SIZE: usize = 16;
 pub const WRAPPER_BLOCK_SIZE: usize = WRAPPER_BLOCK_PAYLOAD_SIZE + BLOCK_HEADER_SIZE;
 
-// Node reads land on block boundaries and need them aligned; see
-// `hypertree::get_helper`.
+// Given Solana's eight-byte-aligned account-data base, this block size
+// preserves alignment at every node boundary. Safe byte-slice helpers still
+// validate arbitrary input bases; see `hypertree::get_helper`.
 const_assert_eq!(WRAPPER_BLOCK_SIZE % 8, 0);
 
 // This is the maximum number of order ids/cancels assembled for one core CPI;


### PR DESCRIPTION
get_helper and get_mut_helper asserted the node's alignment on every call. Every index into an account's dynamic data is a block boundary, the block sizes are multiples of eight, the fixed header before them is too, and the runtime hands out account data aligned to sixteen, so the property holds by construction. The block sizes now assert that where they are defined, and the check stays in debug builds and the tests.

A tree walk reads a node per step and a batch update makes many walks, so this was paid thousands of times per transaction. Replaying recorded mainnet order flow: CU per order p50 1,711 to 1,553, p95 2,903 to 2,668, p99 3,351 to 3,052, 7.7% less compute in total. No transaction in the replay got worse.