### PR TITLE
Build the formal verification with the pinned platform tools

### DIFF
--- a/.github/workflows/ci-certora.yml
+++ b/.github/workflows/ci-certora.yml
@@ -29,6 +29,9 @@ jobs:
           working-directory: programs/manifest/src/certora/confs
           certora-key: ${{ secrets.CERTORAKEY }}
           cli-version: "8.13.0"
-          certora-sbf-options: "-vvv --tools-version=v1.43"
+          # Must match workspace.metadata.solana.tools-version. This overrides
+          # the workspace pin, and v1.43 ships rustc 1.79, which cannot build
+          # the pinocchio account view crates the programs now use.
+          certora-sbf-options: "-vvv --tools-version=v1.57"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/programs/manifest/src/certora/confs/base.conf
+++ b/programs/manifest/src/certora/confs/base.conf
@@ -16,5 +16,5 @@
           ],
    "server": "production",
    "rule_sanity": "basic",
-   "cargo_tools_version": "v1.43",
+   "cargo_tools_version": "v1.57",
 }

--- a/programs/manifest/src/certora/just/build.just
+++ b/programs/manifest/src/certora/just/build.just
@@ -15,11 +15,11 @@ test-certora *TESTS:
 	cargo test --features certora-test {{TESTS}} -- --nocapture
 
 build-sbf extra_features="":
-	cargo certora-sbf --tools-version v1.43 --features certora {{ extra_features }} ${CARGO_FEATURES}
+	cargo certora-sbf --tools-version v1.57 --features certora {{ extra_features }} ${CARGO_FEATURES}
 
 build-sbf-llvm:
 	env RUSTFLAGS="--emit=llvm-ir -C no-vectorize-slp -C opt-level=2" \
-	cargo certora-sbf --tools-version v1.43 --features certora ${CARGO_FEATURES}
+	cargo certora-sbf --tools-version v1.57 --features certora ${CARGO_FEATURES}
 
 build:
 	cargo build


### PR DESCRIPTION
The prover was still building with platform tools v1.43, which ships rustc 1.79. The programs now use pinocchio, whose account view crates need 1.89 or newer, so that build cannot succeed at all.

Three places pinned it: the conf the prover actually builds from, the recipes for running it by hand, and the flag the action passes. All move to v1.57, which is what workspace.metadata.solana already pins for every other build in the repository.