### PR TITLE
Build the formal verification with the tools the prover accepts

### DIFF
--- a/.github/workflows/ci-certora.yml
+++ b/.github/workflows/ci-certora.yml
@@ -29,9 +29,13 @@ jobs:
           working-directory: programs/manifest/src/certora/confs
           certora-key: ${{ secrets.CERTORAKEY }}
           cli-version: "8.13.0"
-          # Must match workspace.metadata.solana.tools-version. This overrides
-          # the workspace pin, and v1.43 ships rustc 1.79, which cannot build
-          # the pinocchio account view crates the programs now use.
-          certora-sbf-options: "-vvv --tools-version=v1.57"
+          # Deliberately not workspace.metadata.solana.tools-version, which is
+          # v1.57. `cargo certora-sbf` refuses anything newer than v1.53, and
+          # the pinocchio account view crates need rustc 1.89, which v1.43 (on
+          # 1.79) does not have. v1.53 ships exactly 1.89, so it is the only
+          # version that satisfies both. The prover therefore verifies a build
+          # from a slightly older compiler than the deployed one; it reasons
+          # about the program's semantics, not its compute.
+          certora-sbf-options: "-vvv --tools-version=v1.53"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/programs/manifest/justfile
+++ b/programs/manifest/justfile
@@ -58,11 +58,11 @@ test-certora *TESTS:
 	cargo test --features certora-test {{TESTS}} -- --nocapture
 
 build-sbf extra_features="":
-	cargo certora-sbf --tools-version v1.43 --features certora {{ extra_features }} ${CARGO_FEATURES}
+	cargo certora-sbf --tools-version v1.53 --features certora {{ extra_features }} ${CARGO_FEATURES}
 
 build-sbf-llvm:
 	env RUSTFLAGS="--emit=llvm-ir -C no-vectorize-slp -C opt-level=2" \
-	cargo certora-sbf --tools-version v1.43 --features certora ${CARGO_FEATURES}
+	cargo certora-sbf --tools-version v1.53 --features certora ${CARGO_FEATURES}
 
 build:
 	cargo build

--- a/programs/manifest/src/certora/confs/base.conf
+++ b/programs/manifest/src/certora/confs/base.conf
@@ -16,5 +16,5 @@
           ],
    "server": "production",
    "rule_sanity": "basic",
-   "cargo_tools_version": "v1.57",
+   "cargo_tools_version": "v1.53",
 }

--- a/programs/manifest/src/certora/just/build.just
+++ b/programs/manifest/src/certora/just/build.just
@@ -15,11 +15,11 @@ test-certora *TESTS:
 	cargo test --features certora-test {{TESTS}} -- --nocapture
 
 build-sbf extra_features="":
-	cargo certora-sbf --tools-version v1.57 --features certora {{ extra_features }} ${CARGO_FEATURES}
+	cargo certora-sbf --tools-version v1.53 --features certora {{ extra_features }} ${CARGO_FEATURES}
 
 build-sbf-llvm:
 	env RUSTFLAGS="--emit=llvm-ir -C no-vectorize-slp -C opt-level=2" \
-	cargo certora-sbf --tools-version v1.57 --features certora ${CARGO_FEATURES}
+	cargo certora-sbf --tools-version v1.53 --features certora ${CARGO_FEATURES}
 
 build:
 	cargo build


### PR DESCRIPTION
The previous change moved the prover to v1.57 to match the rest of the repository. It cannot use that: `cargo certora-sbf` refuses any version newer than v1.53, so the build failed before compiling anything.

v1.53 is the version that works. The pinocchio account view crates need rustc 1.89, which is why v1.43 could not build them at all, and v1.53 ships exactly 1.89 while v1.57 ships 1.95. That makes v1.53 the only version satisfying both constraints, so the prover deliberately builds with an older compiler than the deployed programs. It reasons about what the program does rather than what it costs, so that difference does not affect the rules.

Pinned in the three places that select it: the conf the prover builds from, the recipes for running it by hand, and the flag the action passes.