### PR TITLE
Cancel every tracked order in one cancel_all

### DIFF
--- a/programs/wrapper/src/processors/shared.rs
+++ b/programs/wrapper/src/processors/shared.rs
@@ -89,9 +89,12 @@ pub const WRAPPER_BLOCK_SIZE: usize = WRAPPER_BLOCK_PAYLOAD_SIZE + BLOCK_HEADER_
 // validate arbitrary input bases; see `hypertree::get_helper`.
 const_assert_eq!(WRAPPER_BLOCK_SIZE % 8, 0);
 
-// This is the maximum number of order ids/cancels assembled for one core CPI;
-// it is not a market traversal budget. Bounded traversals have their own
-// explicit step quotas and persistent progress state.
+// The order id/cancel count a batch is expected to carry, used to size the
+// vectors that collect them. It is a starting capacity, not a limit: a batch
+// with more cancels than this, including a cancel_all over more tracked
+// orders, grows them and is processed in full. It is not a market traversal
+// budget either; bounded traversals have their own explicit step quotas and
+// persistent progress state.
 pub const EXPECTED_ORDER_BATCH_SIZE: usize = 16;
 
 /// Blocks added per wrapper expansion. Growing costs a system transfer CPI
@@ -305,14 +308,16 @@ impl<'a> CancelMatcher<'a> {
     ///
     /// A batch is a handful of ids, so comparing each open order against all
     /// of them costs a few CU per order, where hashing cost hundreds.
-    /// cancel_all is bounded to EXPECTED_ORDER_BATCH_SIZE wrapper-tracked
-    /// cancels per transaction so its CPI work stays bounded; shared market
-    /// size cannot affect this path. Orders placed directly through the core
-    /// are intentionally excluded and remain cancellable by sequence
-    /// number/index. The rest of the tracked orders are left for a retry.
+    /// cancel_all takes every order this wrapper tracks, however many that is,
+    /// so one call cancels all of them instead of leaving a remainder for the
+    /// caller to notice and retry. The work is proportional to the trader's own
+    /// open orders, which they alone create and pay rent for; shared market
+    /// size still cannot affect this path, because orders placed directly
+    /// through the core are not tracked here and remain cancellable by
+    /// sequence number/index.
     fn matches(&self, order: &WrapperOpenOrder) -> bool {
         if self.cancel_all {
-            self.core_cancels.len() < EXPECTED_ORDER_BATCH_SIZE
+            true
         } else {
             self.cancels
                 .iter()

--- a/programs/wrapper/tests/cases/batch_update.rs
+++ b/programs/wrapper/tests/cases/batch_update.rs
@@ -446,7 +446,7 @@ async fn wrapper_batch_update_cancel_all_test() -> anyhow::Result<()> {
         "Wrapper and direct asks before cancel_all"
     );
 
-    // cancel_all is bounded to 16 owned cancellations per transaction.
+    // cancel_all takes every order the wrapper tracks, in one transaction.
     let batch_update_ix: Instruction = batch_update_instruction(
         &test_fixture.market.key,
         &payer,
@@ -471,12 +471,12 @@ async fn wrapper_batch_update_cancel_all_test() -> anyhow::Result<()> {
             .get_asks()
             .iter::<RestingOrder>()
             .count(),
-        2,
-        "First bounded cancel_all leaves work for a retry",
+        1,
+        "One cancel_all clears all 17 tracked asks, leaving only the direct-core one",
     );
 
-    // The wrapper sync consumed all 16 core cancellation slots. The reserved
-    // legacy scan field remains untouched.
+    // Every tracked order went in one pass. The reserved legacy scan field
+    // remains untouched.
     let mut wrapper_account_after_first_pass: Account = test_fixture
         .context
         .borrow_mut()
@@ -551,8 +551,9 @@ async fn wrapper_batch_update_cancel_all_test() -> anyhow::Result<()> {
         "cancel_all does not update the reserved legacy scan field",
     );
 
-    // The direct-core order remains. cancel_all deliberately limits its work
-    // to orders tracked by this wrapper so unrelated market size cannot affect
+    // The direct-core order remains: a second cancel_all is a no-op because
+    // the wrapper tracks nothing more. cancel_all still limits its work to
+    // orders tracked by this wrapper, so unrelated market size cannot affect
     // its compute cost.
     test_fixture.market.reload().await;
     assert_eq!(


### PR DESCRIPTION
cancel_all stopped after EXPECTED_ORDER_BATCH_SIZE orders and left the rest for the caller to retry, so a trader with more than sixteen open orders got a partial cancel from an instruction whose whole purpose is to leave nothing behind. Nothing in the response said work remained; the caller had to compare the book against its own records to find out.

Now it takes every order the wrapper tracks. The cost is proportional to the trader's own open orders, which only they create and pay rent for, so the bound the cap was protecting, that a shared market's size cannot be used to inflate this path, is unchanged: orders placed directly through the core are not tracked by the wrapper and are still cancelled by sequence number or index.

EXPECTED_ORDER_BATCH_SIZE stays as the starting capacity for the vectors that collect the cancels, which is what it is now used for.

The existing test already places seventeen wrapper-tracked asks, one more than the old cap, and needed two passes to clear them. It now clears them in one and keeps the second pass as an idempotency check.