### PR TITLE
Snapshot trader positions before saving them

### DIFF
--- a/scripts/stats_utils/manifestStatsServer.ts
+++ b/scripts/stats_utils/manifestStatsServer.ts
@@ -2675,10 +2675,27 @@ export class ManifestStatsServer {
       const delay = (ms: number | undefined): Promise<void> =>
         new Promise((resolve) => setTimeout(resolve, ms));
 
+      // Copy the positions before the first await. The loop below yields to
+      // the event loop between traders, and during that time
+      // pruneInactiveTraders can delete a trader while a new fill re-adds it.
+      // A Map iterator revisits a key that is deleted and re-added
+      // mid-iteration, which would insert the same (checkpoint_id, trader,
+      // mint) twice and violate the primary key. The copy is synchronous, so
+      // it is also a consistent point-in-time snapshot of every trader.
+      const positionsSnapshot: [
+        string,
+        Map<string, number>,
+        Map<string, number>,
+      ][] = Array.from(this.traderPositions.entries()).map(
+        ([trader, positions]) => [
+          trader,
+          new Map(positions),
+          new Map(this.traderAcquisitionValue.get(trader) || []),
+        ],
+      );
+
       let traderCount: number = 0;
-      for (const [trader, positions] of this.traderPositions.entries()) {
-        const acquisitionValues: Map<string, number> =
-          this.traderAcquisitionValue.get(trader) || new Map();
+      for (const [trader, positions, acquisitionValues] of positionsSnapshot) {
         const positionBatchPromises: Promise<QueryResult>[] = [];
 
         for (const [mint, position] of positions.entries()) {

--- a/scripts/stats_utils/queries.ts
+++ b/scripts/stats_utils/queries.ts
@@ -21,8 +21,14 @@ export const INSERT_MARKET_CHECKPOINT =
 export const INSERT_TRADER_STATS =
   'INSERT INTO trader_stats (checkpoint_id, trader, num_taker_trades, num_maker_trades, taker_notional_volume, maker_notional_volume) VALUES ($1, $2, $3, $4, $5, $6)';
 
-export const INSERT_TRADER_POSITION =
-  'INSERT INTO trader_positions (checkpoint_id, trader, mint, position, acquisition_value) VALUES ($1, $2, $3, $4, $5)';
+// ON CONFLICT is a backstop: saveTraderData writes from a snapshot so a
+// (checkpoint_id, trader, mint) row should never be inserted twice, but a
+// duplicate must not roll back the whole trader checkpoint if it ever is.
+export const INSERT_TRADER_POSITION = `
+  INSERT INTO trader_positions (checkpoint_id, trader, mint, position, acquisition_value)
+  VALUES ($1, $2, $3, $4, $5)
+  ON CONFLICT (checkpoint_id, trader, mint) DO NOTHING
+`;
 
 // ========== SELECT QUERIES ==========
 


### PR DESCRIPTION
saveTraderData iterated the live traderPositions Map while awaiting between traders. pruneInactiveTraders (run from advanceCheckpoints every 5 minutes) can delete a trader during that window, and a new fill re-adds the key. A Map iterator revisits a key that is deleted and re-added mid-iteration, so the same (checkpoint_id, trader, mint) row was inserted twice, violating trader_positions_pkey and rolling back the whole hourly trader checkpoint.

Copy positions and acquisition values synchronously before the first await, which both prevents the revisit and makes the checkpoint a consistent point-in-time snapshot. Add ON CONFLICT DO NOTHING to the insert as a backstop so a duplicate can never roll back the transaction.